### PR TITLE
import print_function from __future__

### DIFF
--- a/pysynphot/Cache.py
+++ b/pysynphot/Cache.py
@@ -9,7 +9,7 @@ Kurucz and Castelli-Kurucz model atlases.
 
 """
 
-from __future__ import division
+from __future__ import division, print_function
 from locations import RedLaws
 
 # if PYSYN_CDBS is undefined RedLaws will be an empty dictionary

--- a/pysynphot/__init__.py
+++ b/pysynphot/__init__.py
@@ -80,7 +80,7 @@ angstrom
 flam
 
 """
-from __future__ import division
+from __future__ import division, print_function
 
 #UI:
 #AnalyticSpectra:

--- a/pysynphot/binning.py
+++ b/pysynphot/binning.py
@@ -5,7 +5,7 @@ Utilities related to wavelength bin calculations.
 
 """
 
-from __future__ import division
+from __future__ import division, print_function
 import numpy as np
 
 

--- a/pysynphot/catalog.py
+++ b/pysynphot/catalog.py
@@ -19,7 +19,7 @@ http://www.stsci.edu/hst/HST_overview/documents/synphot/AppA_Catalogs.html#57
 
 """
 
-from __future__ import division
+from __future__ import division, print_function
 
 import os
 import numpy as np

--- a/pysynphot/exceptions.py
+++ b/pysynphot/exceptions.py
@@ -5,7 +5,8 @@ Custom exceptions for pysynphot to raise
 
 """
 
-from __future__ import division
+from __future__ import division, print_function
+
 
 class PysynphotError(Exception):
     """

--- a/pysynphot/extinction.py
+++ b/pysynphot/extinction.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import division
+from __future__ import division, print_function
 import string
 import numpy as np
 import spectrum

--- a/pysynphot/graphtab.py
+++ b/pysynphot/graphtab.py
@@ -7,7 +7,7 @@ http://stackoverflow.com/questions/844505/is-a-graph-library-eg-networkx-the-rig
 
 """
 
-from __future__ import division
+from __future__ import division, print_function
 from collections import defaultdict
 import pyfits
 

--- a/pysynphot/locations.py
+++ b/pysynphot/locations.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import division
+from __future__ import division, print_function
 import glob
 import os
 import re

--- a/pysynphot/obsbandpass.py
+++ b/pysynphot/obsbandpass.py
@@ -9,7 +9,7 @@ ObsModeBandpass (ack, terrible name) or a TabularSpectralElement.
 
 """
 
-from __future__ import division
+from __future__ import division, print_function
 import numpy as np
 
 from observationmode import ObservationMode

--- a/pysynphot/observation.py
+++ b/pysynphot/observation.py
@@ -7,7 +7,7 @@ that has some special methods and attributes and explicitly removes
 certain other methods.
 
 """
-from __future__ import division
+from __future__ import division, print_function
 
 import numpy as np
 import math

--- a/pysynphot/observationmode.py
+++ b/pysynphot/observationmode.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import division
+from __future__ import division, print_function
 import re
 import numpy as np
 

--- a/pysynphot/planck.py
+++ b/pysynphot/planck.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import division
+from __future__ import division, print_function
 import numpy as np
 
 

--- a/pysynphot/reddening.py
+++ b/pysynphot/reddening.py
@@ -6,7 +6,7 @@ extinctions.
 
 """
 
-from __future__ import division
+from __future__ import division, print_function
 import pyfits
 from spectrum import ArraySpectralElement
 import Cache

--- a/pysynphot/refs.py
+++ b/pysynphot/refs.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import division
+from __future__ import division, print_function
 import os.path
 import warnings
 import numpy as np

--- a/pysynphot/renorm.py
+++ b/pysynphot/renorm.py
@@ -6,7 +6,7 @@ one that works, turn it into a method on the spectrum class.
 
 """
 
-from __future__ import division
+from __future__ import division, print_function
 import math
 import numpy as np
 from .spectrum import FlatSpectrum, Vega

--- a/pysynphot/spark.py
+++ b/pysynphot/spark.py
@@ -21,7 +21,7 @@
 #  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 #  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-from __future__ import division
+from __future__ import division, print_function
 import re
 import string
 

--- a/pysynphot/spectrum.py
+++ b/pysynphot/spectrum.py
@@ -15,7 +15,7 @@ pyfits, numpy
 
 """
 
-from __future__ import division
+from __future__ import division, print_function
 
 import re
 import os

--- a/pysynphot/spparser.py
+++ b/pysynphot/spparser.py
@@ -21,7 +21,7 @@ is part of the instructions to the parser.
 
 """
 
-from __future__ import division
+from __future__ import division, print_function
 from spark import GenericScanner
 from spark import GenericASTBuilder, GenericASTMatcher
 import spectrum

--- a/pysynphot/tables.py
+++ b/pysynphot/tables.py
@@ -5,7 +5,7 @@ Objects that represent comp tables and graph tables.
 
 """
 
-from __future__ import division
+from __future__ import division, print_function
 import numpy as np
 import pyfits
 

--- a/pysynphot/units.py
+++ b/pysynphot/units.py
@@ -11,7 +11,7 @@ unit conversions
 
 """
 
-from __future__ import division
+from __future__ import division, print_function
 
 import math
 import numpy as np

--- a/pysynphot/wavetable.py
+++ b/pysynphot/wavetable.py
@@ -8,7 +8,7 @@ set for a given obsmode.
 
 """
 
-from __future__ import division
+from __future__ import division, print_function
 import re
 import numpy as np
 import locations


### PR DESCRIPTION
Astropy style guide dictates that print_function be imported from **future** in addition to division.  Adding import of print_function.
