### PR TITLE
Update to use new astropy config system (APE3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ __pycache__
 *.c
 
 # Other generated files
-*/synphot.cfg
 */version.py
 htmlcov
 .coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,18 @@ python:
     - 2.6
     - 2.7
     - 3.2
-    - 3.3
     - 3.4
 
 env:
     # Try all python versions with the latest numpy
-    - ASTROPY_VERSION=stable NUMPY_VERSION=1.8.0 SETUP_CMD='test'
+    - ASTROPY_VERSION=stable NUMPY_VERSION=1.8 SETUP_CMD='test'
 
 matrix:
     include:
         # Doc build test disabled for now
         #- python: 2.7
         #  # opdeps needed because the matplotlib sphinx extension requires them
-        #  env: ASTROPY_VERSION=stable NUMPY_VERSION=1.8.0 SETUP_CMD='build_sphinx -w -n'
+        #  env: ASTROPY_VERSION=stable NUMPY_VERSION=1.8 SETUP_CMD='build_sphinx -w -n'
 
         # Try alternate numpy versions
         - python: 2.7
@@ -43,7 +42,7 @@ install:
     - if [[ $SETUP_CMD == build_sphinx* ]]; then pip -q install matplotlib --use-mirrors; fi
 
     # Different flavors of astropy
-    - if [[ $ASTROPY_VERSION == stable ]]; then pip -q install astropy==0.3 --use-mirrors; fi
+    - if [[ $ASTROPY_VERSION == stable ]]; then pip -q install astropy==0.4 --use-mirrors; fi
     #- if [[ $ASTROPY_VERSION == development ]]; then pip -q install git+http://github.com/astropy/astropy.git#egg=astropy --use-mirrors; fi
     # Freeze at certain dev commit
     #- if [[ $ASTROPY_VERSION == development ]]; then pip -q install git+git://github.com/astropy/astropy.git@ef19baf695; fi

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,8 +9,8 @@ synphot Documentation
 Currently, ``synphot`` is an astropy-affiliated package.
 It depends on the following external packages:
 
-* `Astropy <http://astropy.org>`_ - Currently requires a special version that has ``modeling``
-  that handles composite models and ``sampleset`` property.
+* `Astropy <http://astropy.org>`_ - Currently requires a special version that
+  has ``modeling`` that handles composite models and ``sampleset`` property.
 * `numpy <http://www.numpy.org/>`_
 * `matplotlib <http://matplotlib.org/>`_ (optional, for plotting)
 
@@ -18,7 +18,6 @@ It is tested with the following Python versions:
 
 * 2.7.5
 * 3.2.3
-* 3.3.2
 * 3.4.0
 
 Contents:

--- a/docs/synphot/reddening.rst
+++ b/docs/synphot/reddening.rst
@@ -16,18 +16,18 @@ from STScI as defined in ``synphot.config``. They can be accessed via
 :func:`~synphot.reddening.ReddeningLaw.from_extinction_model` by providing the
 following model names:
 
-==========  =================  ===========================  ====  =================================================================
-Model name  Config Item        Description                  R(V)  Reference
-==========  =================  ===========================  ====  =================================================================
-'lmc30dor'  ``LMC30DOR_FILE``  LMC2 Supershell              2.76  :ref:`Gordon et al. 2003 <synphot-ref-extinction-gordon2003>`
-'lmcavg'    ``LMCAVG_FILE``    LMC Average                  3.41  :ref:`Gordon et al. 2003 <synphot-ref-extinction-gordon2003>`
-'mwavg'     ``MWAVG_FILE``     Milky Way Diffuse            3.1   :ref:`Cardelli et al. 1989 <synphot-ref-extinction-cardelli1989>`
-'mwdense'   ``MWDENSE_FILE``   Milky Way Dense              5.0   :ref:`Cardelli et al. 1989 <synphot-ref-extinction-cardelli1989>`
-'mwrv21'    ``MWRV21_FILE``    Milky Way CCM                2.1   :ref:`Cardelli et al. 1989 <synphot-ref-extinction-cardelli1989>`
-'mwrv40'    ``MWRV40_FILE``    Milky Way CCM                4.0   :ref:`Cardelli et al. 1989 <synphot-ref-extinction-cardelli1989>`
-'smcbar'    ``SMCBAR_FILE``    SMC Bar                      2.74  :ref:`Gordon et al. 2003 <synphot-ref-extinction-gordon2003>`
-'xgalsb'    ``XGAL_FILE``      Starburst (attenuation law)  4.0   :ref:`Calzetti et al. 2000 <synphot-ref-extinction-calzetti2000>`
-==========  =================  ===========================  ====  =================================================================
+========== ===================================== =========================== ==== =================================================================
+Model name Config Item                           Description                 R(V) Reference
+========== ===================================== =========================== ==== =================================================================
+'lmc30dor' ``synphot.config.conf.lmc30dor_file`` LMC2 Supershell             2.76 :ref:`Gordon et al. 2003 <synphot-ref-extinction-gordon2003>`
+'lmcavg'   ``synphot.config.conf.lmcavg_file``   LMC Average                 3.41 :ref:`Gordon et al. 2003 <synphot-ref-extinction-gordon2003>`
+'mwavg'    ``synphot.config.conf.mwavg_file``    Milky Way Diffuse           3.1  :ref:`Cardelli et al. 1989 <synphot-ref-extinction-cardelli1989>`
+'mwdense'  ``synphot.config.conf.mwdense_file``  Milky Way Dense             5.0  :ref:`Cardelli et al. 1989 <synphot-ref-extinction-cardelli1989>`
+'mwrv21'   ``synphot.config.conf.mwrv21_file``   Milky Way CCM               2.1  :ref:`Cardelli et al. 1989 <synphot-ref-extinction-cardelli1989>`
+'mwrv40'   ``synphot.config.conf.mwrv40_file``   Milky Way CCM               4.0  :ref:`Cardelli et al. 1989 <synphot-ref-extinction-cardelli1989>`
+'smcbar'   ``synphot.config.conf.smcbar_file``   SMC Bar                     2.74 :ref:`Gordon et al. 2003 <synphot-ref-extinction-gordon2003>`
+'xgalsb'   ``synphot.config.conf.xgal_file``     Starburst (attenuation law) 4.0  :ref:`Calzetti et al. 2000 <synphot-ref-extinction-calzetti2000>`
+========== ===================================== =========================== ==== =================================================================
 
 `~synphot.reddening.ReddeningLaw` has similar properties and methods as a
 unitless spectrum (`~synphot.spectrum.BaseUnitlessSpectrum`). Besides

--- a/docs/synphot/spectrum.rst
+++ b/docs/synphot/spectrum.rst
@@ -267,12 +267,12 @@ Vega
 ^^^^
 
 By default, Vega spectrum is downloaded from STScI via configurable item
-``synphot.config.VEGA_FILE``, which requires internet connection, unless a local
-cached copy exists. One can use any desired Vega spectrum as long as it is a
-valid file format, remote or local, by changing the ``VEGA_FILE`` value.
+``synphot.config.conf.vega_file``, which requires internet connection, unless
+a local or cached copy is used. One can use any desired Vega spectrum as long as
+it is a valid file format, remote or local, by changing the ``vega_file`` value.
 
->>> from synphot.config import VEGA_FILE
->>> with VEGA_FILE.set_temp('/grp/hst/cdbs/calspec/alpha_lyr_stis_007.fits'):
+>>> from synphot.config import conf
+>>> with conf.set_temp('vega_file', '/my/path/alpha_lyr_stis_007.fits'):
 ...     vegaspec = SourceSpectrum.from_vega(encoding='binary')
 >>> vegaspec.plot(right=20000, flux_unit=units.FLAM, title='Vega spectrum')
 
@@ -296,22 +296,22 @@ downloaded from STScI as defined in ``synphot.config``. They can be accessed via
 :func:`~synphot.spectrum.SpectralElement.from_filter` by providing the following
 filter names:
 
-===========  ==================  ===========
-Filter name  Config Item         Description
-===========  ==================  ===========
-'bessel_j'   ``BESSEL_J_FILE``   Bessel J
-'bessel_h'   ``BESSEL_H_FILE``   Bessel H
-'bessel_k'   ``BESSEL_K_FILE``   Bessel K
-'cousins_r'  ``COUSINS_R_FILE``  Cousins R
-'cousins_i'  ``COUSINS_I_FILE``  Cousins I
-'johnson_u'  ``JOHNSON_U_FILE``  Johnson U
-'johnson_b'  ``JOHNSON_B_FILE``  Johnson B
-'johnson_v'  ``JOHNSON_V_FILE``  Johnson V
-'johnson_r'  ``JOHNSON_R_FILE``  Johnson R
-'johnson_i'  ``JOHNSON_I_FILE``  Johnson I
-'johnson_j'  ``JOHNSON_J_FILE``  Johnson J
-'johnson_k'  ``JOHNSON_K_FILE``  Johnson K
-===========  ==================  ===========
+===========  ======================================  ===========
+Filter name  Config Item                             Description
+===========  ======================================  ===========
+'bessel_j'   ``synphot.config.conf.bessel_j_file``   Bessel J
+'bessel_h'   ``synphot.config.conf.bessel_h_file``   Bessel H
+'bessel_k'   ``synphot.config.conf.bessel_k_file``   Bessel K
+'cousins_r'  ``synphot.config.conf.cousins_r_file``  Cousins R
+'cousins_i'  ``synphot.config.conf.cousins_i_file``  Cousins I
+'johnson_u'  ``synphot.config.conf.johnson_u_file``  Johnson U
+'johnson_b'  ``synphot.config.conf.johnson_b_file``  Johnson B
+'johnson_v'  ``synphot.config.conf.johnson_v_file``  Johnson V
+'johnson_r'  ``synphot.config.conf.johnson_r_file``  Johnson R
+'johnson_i'  ``synphot.config.conf.johnson_i_file``  Johnson I
+'johnson_j'  ``synphot.config.conf.johnson_j_file``  Johnson J
+'johnson_k'  ``synphot.config.conf.johnson_k_file``  Johnson K
+===========  ======================================  ===========
 
 >>> from synphot import SpectralElement
 >>> johnson_b = SpectralElement.from_filter('johnson_b', encoding='binary')

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ try:
     package_info = get_package_info(PACKAGENAME)
 
     # Add the project-global data
-    package_info['package_data'][PACKAGENAME] = ['data/*']
+    package_info['package_data'].setdefault(PACKAGENAME, []).append('data/*.*')
 
 except ImportError: # compatibility with Astropy 0.2 - can be removed in cases
                     # where Astropy 0.2 is no longer supported
@@ -94,7 +94,7 @@ except ImportError: # compatibility with Astropy 0.2 - can be removed in cases
     package_info['ext_modules'] = []
 
     # A dictionary to keep track of all package data to install
-    package_info['package_data'] = {PACKAGENAME: ['data/*']}
+    package_info['package_data'].setdefault(PACKAGENAME, []).append('data/*.*')
 
     # A dictionary to keep track of extra packagedir mappings
     package_info['package_dir'] = {}
@@ -119,11 +119,11 @@ for root, dirs, files in os.walk(PACKAGENAME):
                     os.path.relpath(root, PACKAGENAME), filename))
 package_info['package_data'][PACKAGENAME].extend(c_files)
 
+# TODO: install_requires=['astropy>=0.4']
 setup(name=PACKAGENAME,
       version=VERSION,
       description=DESCRIPTION,
       scripts=scripts,
-      requires=['astropy'],
       install_requires=['astropy'],
       provides=[PACKAGENAME],
       author=AUTHOR,

--- a/synphot/_astropy_init.py
+++ b/synphot/_astropy_init.py
@@ -121,7 +121,8 @@ if not _ASTROPY_SETUP_:
     if not os.environ.get('ASTROPY_SKIP_CONFIG_UPDATE', False):
         config_dir = os.path.dirname(__file__)
         try:
-            config.configuration.update_default_config(__package__, config_dir)
+            config.configuration.update_default_config(
+                __package__, config_dir, version=__version__)
         except config.configuration.ConfigurationDefaultMissingError as e:
             wmsg = (e.args[0] + " Cannot install default profile. If you are "
                     "importing from source, this is expected.")

--- a/synphot/config.py
+++ b/synphot/config.py
@@ -8,104 +8,83 @@ but it can be easily re-configured as the user wishes via
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-# TODO: Use https://github.com/astropy/astropy/pull/2094 instead.
 # ASTROPY
-from astropy.config.configuration import ConfigurationItem
+from astropy.config import ConfigNamespace, ConfigItem
 
 
-__all__ = ['VEGA_FILE', 'LMC30DOR_FILE', 'LMCAVG_FILE', 'MWAVG_FILE',
-           'MWDENSE_FILE', 'MWRV21_FILE', 'MWRV40_FILE', 'SMCBAR_FILE',
-           'XGAL_FILE', 'BESSEL_H_FILE', 'BESSEL_J_FILE', 'BESSEL_K_FILE',
-           'COUSINS_I_FILE', 'COUSINS_R_FILE', 'JOHNSON_B_FILE',
-           'JOHNSON_I_FILE', 'JOHNSON_J_FILE', 'JOHNSON_K_FILE',
-           'JOHNSON_R_FILE', 'JOHNSON_U_FILE', 'JOHNSON_V_FILE']
+__all__ = ['conf']
 
-# STANDARD STARS
-VEGA_FILE = ConfigurationItem(
-    'vega_file',
-    'ftp://ftp.stsci.edu/cdbs/calspec/alpha_lyr_stis_007.fits',
-    'Vega')
 
-# REDDENING/EXTINCTION LAWS
-LMC30DOR_FILE = ConfigurationItem(
-    'lmc30dor_file',
-    'ftp://ftp.stsci.edu/cdbs/extinction/lmc_30dorshell_001.fits',
-    'Gordon et al. 2003, ApJ, 594, 279; R_V = 2.76')
-LMCAVG_FILE = ConfigurationItem(
-    'lmcavg_file',
-    'ftp://ftp.stsci.edu/cdbs/extinction/lmc_diffuse_001.fits',
-    'Gordon et al. 2003, ApJ, 594, 279; R_V = 3.41')
-MWAVG_FILE = ConfigurationItem(
-    'mwavg_file',
-    'ftp://ftp.stsci.edu/cdbs/extinction/milkyway_diffuse_001.fits',
-    'Cardelli, Clayton, & Mathis 1989, ApJ, 345, 245; R_V = 3.10')
-MWDENSE_FILE = ConfigurationItem(
-    'mwdense_file',
-    'ftp://ftp.stsci.edu/cdbs/extinction/milkyway_dense_001.fits',
-    'Cardelli, Clayton, & Mathis 1989, ApJ, 345, 245; R_V = 5.00')
-MWRV21_FILE = ConfigurationItem(
-    'mwrv21_file',
-    'ftp://ftp.stsci.edu/cdbs/extinction/milkyway_rv21_001.fits',
-    'Cardelli, Clayton, & Mathis 1989, ApJ, 345, 245; R_V = 2.1')
-MWRV40_FILE = ConfigurationItem(
-    'mwrv40_file',
-    'ftp://ftp.stsci.edu/cdbs/extinction/milkyway_rv4_001.fits',
-    'Cardelli, Clayton, & Mathis 1989, ApJ, 345, 245; R_V = 4.0')
-SMCBAR_FILE = ConfigurationItem(
-    'smcbar_file',
-    'ftp://ftp.stsci.edu/cdbs/extinction/smc_bar_001.fits',
-    'Gordon et al. 2003, ApJ, 594, 279; R_V=2.74')
-XGAL_FILE = ConfigurationItem(
-    'xgal_file',
-    'ftp://ftp.stsci.edu/cdbs/extinction/xgal_starburst_001.fits',
-    'Calzetti et al. 2000, ApJ, 533, 682')
+class Conf(ConfigNamespace):
+    """Configuration parameters."""
 
-# COMMON FILTER BANDPASS
-BESSEL_H_FILE = ConfigurationItem(
-    'bessel_h_file',
-    'ftp://ftp.stsci.edu/cdbs/comp/nonhst/bessell_h_004_syn.fits',
-    'Bessel H')
-BESSEL_J_FILE = ConfigurationItem(
-    'bessel_j_file',
-    'ftp://ftp.stsci.edu/cdbs/comp/nonhst/bessell_j_003_syn.fits',
-    'Bessel J')
-BESSEL_K_FILE = ConfigurationItem(
-    'bessel_k_file',
-    'ftp://ftp.stsci.edu/cdbs/comp/nonhst/bessell_k_003_syn.fits',
-    'Bessel K')
-COUSINS_I_FILE = ConfigurationItem(
-    'cousins_i_file',
-    'ftp://ftp.stsci.edu/cdbs/comp/nonhst/cousins_i_004_syn.fits',
-    'Cousins I')
-COUSINS_R_FILE = ConfigurationItem(
-    'cousins_r_file',
-    'ftp://ftp.stsci.edu/cdbs/comp/nonhst/cousins_r_004_syn.fits',
-    'Cousins R')
-JOHNSON_B_FILE = ConfigurationItem(
-    'johnson_b_file',
-    'ftp://ftp.stsci.edu/cdbs/comp/nonhst/johnson_b_004_syn.fits',
-    'Johnson B')
-JOHNSON_I_FILE = ConfigurationItem(
-    'johnson_i_file',
-    'ftp://ftp.stsci.edu/cdbs/comp/nonhst/johnson_i_003_syn.fits',
-    'Johnson I')
-JOHNSON_J_FILE = ConfigurationItem(
-    'johnson_j_file',
-    'ftp://ftp.stsci.edu/cdbs/comp/nonhst/johnson_j_003_syn.fits',
-    'Johnson J')
-JOHNSON_K_FILE = ConfigurationItem(
-    'johnson_k_file',
-    'ftp://ftp.stsci.edu/cdbs/comp/nonhst/johnson_k_003_syn.fits',
-    'Johnson K')
-JOHNSON_R_FILE = ConfigurationItem(
-    'johnson_r_file',
-    'ftp://ftp.stsci.edu/cdbs/comp/nonhst/johnson_r_003_syn.fits',
-    'Johnson R')
-JOHNSON_U_FILE = ConfigurationItem(
-    'johnson_u_file',
-    'ftp://ftp.stsci.edu/cdbs/comp/nonhst/johnson_u_004_syn.fits',
-    'Johnson U')
-JOHNSON_V_FILE = ConfigurationItem(
-    'johnson_v_file',
-    'ftp://ftp.stsci.edu/cdbs/comp/nonhst/johnson_v_004_syn.fits',
-    'Johnson V')
+    # STANDARD STARS
+    vega_file = ConfigItem(
+        'ftp://ftp.stsci.edu/cdbs/calspec/alpha_lyr_stis_007.fits', 'Vega')
+
+    # REDDENING/EXTINCTION LAWS
+    lmc30dor_file = ConfigItem(
+        'ftp://ftp.stsci.edu/cdbs/extinction/lmc_30dorshell_001.fits',
+        'Gordon et al. 2003, ApJ, 594, 279; R_V = 2.76')
+    lmcavg_file = ConfigItem(
+        'ftp://ftp.stsci.edu/cdbs/extinction/lmc_diffuse_001.fits',
+        'Gordon et al. 2003, ApJ, 594, 279; R_V = 3.41')
+    mwavg_file = ConfigItem(
+        'ftp://ftp.stsci.edu/cdbs/extinction/milkyway_diffuse_001.fits',
+        'Cardelli, Clayton, & Mathis 1989, ApJ, 345, 245; R_V = 3.10')
+    mwdense_file = ConfigItem(
+        'ftp://ftp.stsci.edu/cdbs/extinction/milkyway_dense_001.fits',
+        'Cardelli, Clayton, & Mathis 1989, ApJ, 345, 245; R_V = 5.00')
+    mwrv21_file = ConfigItem(
+        'ftp://ftp.stsci.edu/cdbs/extinction/milkyway_rv21_001.fits',
+        'Cardelli, Clayton, & Mathis 1989, ApJ, 345, 245; R_V = 2.1')
+    mwrv40_file = ConfigItem(
+        'ftp://ftp.stsci.edu/cdbs/extinction/milkyway_rv4_001.fits',
+        'Cardelli, Clayton, & Mathis 1989, ApJ, 345, 245; R_V = 4.0')
+    smcbar_file = ConfigItem(
+        'ftp://ftp.stsci.edu/cdbs/extinction/smc_bar_001.fits',
+        'Gordon et al. 2003, ApJ, 594, 279; R_V=2.74')
+    xgal_file = ConfigItem(
+        'ftp://ftp.stsci.edu/cdbs/extinction/xgal_starburst_001.fits',
+        'Calzetti et al. 2000, ApJ, 533, 682')
+
+    # COMMON FILTER BANDPASS
+    bessel_h_file = ConfigItem(
+        'ftp://ftp.stsci.edu/cdbs/comp/nonhst/bessell_h_004_syn.fits',
+        'Bessel H')
+    bessel_j_file = ConfigItem(
+        'ftp://ftp.stsci.edu/cdbs/comp/nonhst/bessell_j_003_syn.fits',
+        'Bessel J')
+    bessel_k_file = ConfigItem(
+        'ftp://ftp.stsci.edu/cdbs/comp/nonhst/bessell_k_003_syn.fits',
+        'Bessel K')
+    cousins_i_file = ConfigItem(
+        'ftp://ftp.stsci.edu/cdbs/comp/nonhst/cousins_i_004_syn.fits',
+        'Cousins I')
+    cousins_r_file = ConfigItem(
+        'ftp://ftp.stsci.edu/cdbs/comp/nonhst/cousins_r_004_syn.fits',
+        'Cousins R')
+    johnson_b_file = ConfigItem(
+        'ftp://ftp.stsci.edu/cdbs/comp/nonhst/johnson_b_004_syn.fits',
+        'Johnson B')
+    johnson_i_file = ConfigItem(
+        'ftp://ftp.stsci.edu/cdbs/comp/nonhst/johnson_i_003_syn.fits',
+        'Johnson I')
+    johnson_j_file = ConfigItem(
+        'ftp://ftp.stsci.edu/cdbs/comp/nonhst/johnson_j_003_syn.fits',
+        'Johnson J')
+    johnson_k_file = ConfigItem(
+        'ftp://ftp.stsci.edu/cdbs/comp/nonhst/johnson_k_003_syn.fits',
+        'Johnson K')
+    johnson_r_file = ConfigItem(
+        'ftp://ftp.stsci.edu/cdbs/comp/nonhst/johnson_r_003_syn.fits',
+        'Johnson R')
+    johnson_u_file = ConfigItem(
+        'ftp://ftp.stsci.edu/cdbs/comp/nonhst/johnson_u_004_syn.fits',
+        'Johnson U')
+    johnson_v_file = ConfigItem(
+        'ftp://ftp.stsci.edu/cdbs/comp/nonhst/johnson_v_004_syn.fits',
+        'Johnson V')
+
+
+conf = Conf()

--- a/synphot/reddening.py
+++ b/synphot/reddening.py
@@ -173,21 +173,21 @@ class ReddeningLaw(BaseUnitlessSpectrum):
 
         # Select filename based on model name
         if modelname == 'lmc30dor':
-            cfgitem = config.LMC30DOR_FILE
+            cfgitem = config.conf.__class__.lmc30dor_file
         elif modelname == 'lmcavg':
-            cfgitem = config.LMCAVG_FILE
+            cfgitem = config.conf.__class__.lmcavg_file
         elif modelname == 'mwavg':
-            cfgitem = config.MWAVG_FILE
+            cfgitem = config.conf.__class__.mwavg_file
         elif modelname == 'mwdense':
-            cfgitem = config.MWDENSE_FILE
+            cfgitem = config.conf.__class__.mwdense_file
         elif modelname == 'mwrv21':
-            cfgitem = config.MWRV21_FILE
+            cfgitem = config.conf.__class__.mwrv21_file
         elif modelname == 'mwrv40':
-            cfgitem = config.MWRV40_FILE
+            cfgitem = config.conf.__class__.mwrv40_file
         elif modelname == 'smcbar':
-            cfgitem = config.SMCBAR_FILE
+            cfgitem = config.conf.__class__.smcbar_file
         elif modelname == 'xgalsb':
-            cfgitem = config.XGAL_FILE
+            cfgitem = config.conf.__class__.xgal_file
         else:
             raise exceptions.SynphotError(
                 'Extinction model {0} is invalid.'.format(modelname))

--- a/synphot/spectrum.py
+++ b/synphot/spectrum.py
@@ -1113,7 +1113,7 @@ class SourceSpectrum(BaseSourceSpectrum):
             Empirical Vega spectrum.
 
         """
-        filename = config.VEGA_FILE()
+        filename = config.conf.vega_file
         header, wavelengths, fluxes = specio.read_remote_spec(
             filename, **kwargs)
         header['expr'] = 'Vega from {0}'.format(os.path.basename(filename))
@@ -1707,29 +1707,29 @@ class SpectralElement(BaseUnitlessSpectrum):
 
         # Select filename based on filter name
         if filtername == 'bessel_j':
-            cfgitem = config.BESSEL_J_FILE
+            cfgitem = config.conf.__class__.bessel_j_file
         elif filtername == 'bessel_h':
-            cfgitem = config.BESSEL_H_FILE
+            cfgitem = config.conf.__class__.bessel_h_file
         elif filtername == 'bessel_k':
-            cfgitem = config.BESSEL_K_FILE
+            cfgitem = config.conf.__class__.bessel_k_file
         elif filtername == 'cousins_r':
-            cfgitem = config.COUSINS_R_FILE
+            cfgitem = config.conf.__class__.cousins_r_file
         elif filtername == 'cousins_i':
-            cfgitem = config.COUSINS_I_FILE
+            cfgitem = config.conf.__class__.cousins_i_file
         elif filtername == 'johnson_u':
-            cfgitem = config.JOHNSON_U_FILE
+            cfgitem = config.conf.__class__.johnson_u_file
         elif filtername == 'johnson_b':
-            cfgitem = config.JOHNSON_B_FILE
+            cfgitem = config.conf.__class__.johnson_b_file
         elif filtername == 'johnson_v':
-            cfgitem = config.JOHNSON_V_FILE
+            cfgitem = config.conf.__class__.johnson_v_file
         elif filtername == 'johnson_r':
-            cfgitem = config.JOHNSON_R_FILE
+            cfgitem = config.conf.__class__.johnson_r_file
         elif filtername == 'johnson_i':
-            cfgitem = config.JOHNSON_I_FILE
+            cfgitem = config.conf.__class__.johnson_i_file
         elif filtername == 'johnson_j':
-            cfgitem = config.JOHNSON_J_FILE
+            cfgitem = config.conf.__class__.johnson_j_file
         elif filtername == 'johnson_k':
-            cfgitem = config.JOHNSON_K_FILE
+            cfgitem = config.conf.__class__.johnson_k_file
         else:
             raise exceptions.SynphotError(
                 'Filter name {0} is invalid.'.format(filtername))

--- a/synphot/synphot.cfg
+++ b/synphot/synphot.cfg
@@ -1,0 +1,28 @@
+[config]
+
+## Vega
+# vega_file = ftp://ftp.stsci.edu/cdbs/calspec/alpha_lyr_stis_007.fits
+
+## Reddening/extinction laws
+# lmc30dor_file = ftp://ftp.stsci.edu/cdbs/extinction/lmc_30dorshell_001.fits
+# lmcavg_file = ftp://ftp.stsci.edu/cdbs/extinction/lmc_diffuse_001.fits
+# mwavg_file = ftp://ftp.stsci.edu/cdbs/extinction/milkyway_diffuse_001.fits
+# mwdense_file = ftp://ftp.stsci.edu/cdbs/extinction/milkyway_dense_001.fits
+# mwrv21_file = ftp://ftp.stsci.edu/cdbs/extinction/milkyway_rv21_001.fits
+# mwrv40_file = ftp://ftp.stsci.edu/cdbs/extinction/milkyway_rv4_001.fits
+# smcbar_file = ftp://ftp.stsci.edu/cdbs/extinction/smc_bar_001.fits
+# xgal_file = ftp://ftp.stsci.edu/cdbs/extinction/xgal_starburst_001.fits
+
+## Common filter bandpass
+# bessel_h_file = ftp://ftp.stsci.edu/cdbs/comp/nonhst/bessell_h_004_syn.fits
+# bessel_j_file = ftp://ftp.stsci.edu/cdbs/comp/nonhst/bessell_j_003_syn.fits
+# bessel_k_file = ftp://ftp.stsci.edu/cdbs/comp/nonhst/bessell_k_003_syn.fits
+# cousins_i_file = ftp://ftp.stsci.edu/cdbs/comp/nonhst/cousins_i_004_syn.fits
+# cousins_r_file = ftp://ftp.stsci.edu/cdbs/comp/nonhst/cousins_r_004_syn.fits
+# johnson_b_file = ftp://ftp.stsci.edu/cdbs/comp/nonhst/johnson_b_004_syn.fits
+# johnson_i_file = ftp://ftp.stsci.edu/cdbs/comp/nonhst/johnson_i_003_syn.fits
+# johnson_j_file = ftp://ftp.stsci.edu/cdbs/comp/nonhst/johnson_j_003_syn.fits
+# johnson_k_file = ftp://ftp.stsci.edu/cdbs/comp/nonhst/johnson_k_003_syn.fits
+# johnson_r_file = ftp://ftp.stsci.edu/cdbs/comp/nonhst/johnson_r_003_syn.fits
+# johnson_u_file = ftp://ftp.stsci.edu/cdbs/comp/nonhst/johnson_u_004_syn.fits
+# johnson_v_file = ftp://ftp.stsci.edu/cdbs/comp/nonhst/johnson_v_004_syn.fits

--- a/synphot/tests/test_specio.py
+++ b/synphot/tests/test_specio.py
@@ -29,9 +29,9 @@ def test_read_remote_spec():
     """
     from .. import config
 
-    specfile = config.VEGA_FILE()
     hdr, wave, flux = specio.read_remote_spec(
-        specfile, cache=False, show_progress=False, encoding='binary')
+        config.conf.vega_file, cache=False, show_progress=False,
+        encoding='binary')
 
     assert isinstance(wave, u.Quantity)
     assert isinstance(flux, u.Quantity)


### PR DESCRIPTION
- Use new `astropy` configuration system (APE3; astropy/astropy#2094)
- Fixed installer
- Updated Travis; dropped support for Python 3.3 testing
- Updated docs and tests
