### PR TITLE
Use new Tabular model in Astropy

### DIFF
--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -104,8 +104,8 @@ class Observation(BaseSourceSpectrum):
                 warn['PartialOverlap'] = msg
 
                 if isinstance(spec.model, Empirical1D):
-                    spec.model.set_interp1d(fill_value='extrapolate',
-                                            kind='nearest')
+                    spec.model.method = 'nearest'
+                    spec.model.fill_value = None
             else:
                 raise exceptions.SynphotError(
                     'force={0} is invalid, must be "none", "taper", '
@@ -684,4 +684,5 @@ class Observation(BaseSourceSpectrum):
                 wavelengths, flux_unit=self._internal_flux_unit)
 
         header = {'observation': str(self), 'binned': binned}
-        return SourceSpectrum(Empirical1D, x=w, y=y, meta={'header': header})
+        return SourceSpectrum(Empirical1D, points=w, lookup_table=y,
+                              meta={'header': header})

--- a/synphot/reddening.py
+++ b/synphot/reddening.py
@@ -67,8 +67,9 @@ class ReddeningLaw(BaseUnitlessSpectrum):
             'E(B-V)': ebv,
             'ReddeningLaw': self.meta.get('expr', 'unknown')}
 
-        return ExtinctionCurve(Empirical1D, x=x, y=y, meta={'header': header},
-                               fill_value='extrapolate')
+        return ExtinctionCurve(
+            Empirical1D, points=x, lookup_table=y, meta={'header': header},
+            fill_value=None)
 
     def to_fits(self, filename, wavelengths=None, **kwargs):
         """Write the reddening law to a FITS file.
@@ -145,8 +146,9 @@ class ReddeningLaw(BaseUnitlessSpectrum):
             kwargs['flux_col'] = 'Av/E(B-V)'
 
         header, wavelengths, rvs = specio.read_spec(filename, **kwargs)
-        return cls(Empirical1D, x=wavelengths, y=rvs, meta={'header': header},
-                   fill_value='extrapolate')
+
+        return cls(Empirical1D, points=wavelengths, lookup_table=rvs,
+                   meta={'header': header}, fill_value=None)
 
     @classmethod
     def from_extinction_model(cls, modelname, **kwargs):
@@ -208,8 +210,9 @@ class ReddeningLaw(BaseUnitlessSpectrum):
         header['filename'] = filename
         header['descrip'] = cfgitem.description
         meta = {'header': header, 'expr': modelname}
-        return cls(Empirical1D, x=wavelengths, y=rvs, meta=meta,
-                   fill_value='extrapolate')
+
+        return cls(Empirical1D, points=wavelengths, lookup_table=rvs,
+                   meta=meta, fill_value=None)
 
 
 class ExtinctionCurve(BaseUnitlessSpectrum):

--- a/synphot/tests/test_models.py
+++ b/synphot/tests/test_models.py
@@ -115,7 +115,8 @@ class TestEmpirical1D(object):
         y = units.convert_flux(x, f, units.PHOTLAM)
         self.flux_flam = f.value
         self.w = x.value
-        self.m = Empirical1D(x=self.w, y=y.value, kind='linear')
+        self.m = Empirical1D(
+            points=self.w, lookup_table=y.value, method='linear')
 
     def test_sampleset(self):
         np.testing.assert_array_equal(self.m.sampleset(), self.w)
@@ -142,7 +143,7 @@ class TestEmpirical1D(object):
             rtol=1e-6)
 
         # New model with descending order
-        m2 = Empirical1D(x=w2, y=f2)
+        m2 = Empirical1D(points=w2, lookup_table=f2)
         y = units.convert_flux(w, m2(w), units.FLAM)
         np.testing.assert_allclose(
             y.value, [8.57166622e-15, 8.86174843e-15, 8.68707743e-15],
@@ -153,7 +154,8 @@ class TestEmpirical1D(object):
         [(True, [-1.1, 0, 1.1]),
          (False, [0, 0, 1.1])])
     def test_neg(self, keep_neg, ans):
-        m2 = Empirical1D(x=[1, 2, 3], y=[-1.1, 0, 1.1], keep_neg=keep_neg)
+        m2 = Empirical1D(points=[1, 2, 3], lookup_table=[-1.1, 0, 1.1],
+                         keep_neg=keep_neg)
         np.testing.assert_array_equal(m2([1, 2, 3]), ans)
         if not keep_neg:
             assert 'NegativeFlux' in m2.meta['warnings']

--- a/synphot/tests/test_observation.py
+++ b/synphot/tests/test_observation.py
@@ -61,7 +61,8 @@ class TestObservation(object):
     def test_disjoint_spec(self):
         """The rest of overlap logic is tested in `TestInitWithForce`."""
         sp = SourceSpectrum(
-            Empirical1D, x=[39999.9, 40000, 40001, 40001.1], y=[0, 1, 1, 0])
+            Empirical1D, points=[39999.9, 40000, 40001, 40001.1],
+            lookup_table=[0, 1, 1, 0])
         with pytest.raises(exceptions.DisjointError):
             obs2 = Observation(sp, self.obs.bandpass)
 
@@ -164,9 +165,10 @@ class TestInitWithForce(object):
         x = np.arange(3000, 4000)
         y = np.ones_like(x) * 0.75
         self.sp = SourceSpectrum(
-            Empirical1D, x=x, y=y, meta={'expr': 'short flat'})
+            Empirical1D, points=x, lookup_table=y, meta={'expr': 'short flat'})
         self.bp = SpectralElement(
-            Empirical1D, x=[3949.9, 3950, 4050, 4050.1], y=[0, 1, 1, 0])
+            Empirical1D, points=[3949.9, 3950, 4050, 4050.1],
+            lookup_table=[0, 1, 1, 0])
 
     @pytest.mark.parametrize(
         ('force_type', 'ans'),
@@ -326,10 +328,11 @@ class TestCountRate(object):
         x = np.arange(1000, 1100, 0.5)
         y = units.convert_flux(
             x, (x - 1000) * u.count, units.PHOTLAM, area=_area).value
-        sp = SourceSpectrum(Empirical1D, x=x, y=y, meta={'expr': 'slope1'})
+        sp = SourceSpectrum(Empirical1D, points=x, lookup_table=y,
+                            meta={'expr': 'slope1'})
         bp = SpectralElement(
-            Empirical1D, x=[1009.95, 1010, 1030, 1030.05],
-            y=[0, 1, 1, 0], meta={'expr': 'handmade_box'})
+            Empirical1D, points=[1009.95, 1010, 1030, 1030.05],
+            lookup_table=[0, 1, 1, 0], meta={'expr': 'handmade_box'})
         self.obs = Observation(sp, bp, binset=np.arange(1000, 1020))
 
     @pytest.mark.parametrize(

--- a/synphot/tests/test_reddening.py
+++ b/synphot/tests/test_reddening.py
@@ -47,10 +47,10 @@ class TestExtinction(object):
         w = self.redlaw.waveset[48:53]
         np.testing.assert_allclose(
             w.to(u.micron ** -1, u.spectral()).value,
-            [5.03399992, 5.12949991, 5.2249999, 5.3204999, 5.41599989])
+            [5.41599989, 5.3204999, 5.2249999, 5.12949991, 5.03399992])
         np.testing.assert_allclose(
             self.redlaw(w).value,
-            [8.69231796, 8.40150452, 8.17892265, 8.01734924, 7.90572977])
+            [7.90572977, 8.01734924, 8.17892265, 8.40150452, 8.69231796])
 
     def test_extcurve_call(self):
         w = self.extcurve.waveset
@@ -101,7 +101,8 @@ class TestWriteReddeningLaw(object):
         self.outdir = tempfile.mkdtemp()
         self.x = np.linspace(1000, 5000, 5)
         self.y = np.linspace(1, 5, 5) * 0.1
-        self.redlaw = ReddeningLaw(Empirical1D, x=self.x, y=self.y)
+        self.redlaw = ReddeningLaw(
+            Empirical1D, points=self.x, lookup_table=self.y)
 
     @pytest.mark.parametrize('ext_hdr', [None, {'foo': 'foo'}])
     def test_write(self, ext_hdr):

--- a/synphot/thermal.py
+++ b/synphot/thermal.py
@@ -146,5 +146,6 @@ class ThermalSpectralElement(BaseUnitlessSpectrum):
             kwargs['flux_col'] = 'EMISSIVITY'
 
         header, wavelengths, em = specio.read_spec(filename, **kwargs)
-        return cls(Empirical1D, temperature, beam_fill_factor=beam_fill_factor,
-                   x=wavelengths, y=em, meta={'header': header})
+        return cls(
+            Empirical1D, temperature, beam_fill_factor=beam_fill_factor,
+            points=wavelengths, lookup_table=em, meta={'header': header})


### PR DESCRIPTION
Use new `TabularModel` in Astropy, as implemented in astropy/astropy#5105. Also see spacetelescope/gwcs#28.

TODO:

- [x] Run tests after astropy/astropy#5105 and astropy/astropy#5183 are merged. They already passed on local machine.
- [x] Remove CI YAML hacks for both Travis and Appveyor to use Nadia's branch.
- [x] Also file equivalent PR for `stsynphot` (see spacetelescope/stsynphot_refactor#22).