### PR TITLE
__call__ to perform unit conversion

### DIFF
--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -225,8 +225,7 @@ class Observation(BaseSourceSpectrum):
             wavelengths = self._validate_wavelengths(wave)
         return wavelengths
 
-    def sample_binned(self, wavelengths=None, flux_unit=units.PHOTLAM,
-                      **kwargs):
+    def sample_binned(self, wavelengths=None, flux_unit=None, **kwargs):
         """Sample binned observation without interpolation.
 
         To sample unbinned data, use ``__call__``.
@@ -238,8 +237,9 @@ class Observation(BaseSourceSpectrum):
             If not a Quantity, assumed to be in Angstrom.
             If `None`, `binset` is used.
 
-        flux_unit : str or `~astropy.units.core.Unit`
+        flux_unit : str or `~astropy.units.core.Unit` or `None`
             Flux is converted to this unit.
+            If not given, internal unit is used.
 
         kwargs : dict
             Keywords acceptable by :func:`~synphot.units.convert_flux`.
@@ -261,7 +261,13 @@ class Observation(BaseSourceSpectrum):
             raise exceptions.InterpolationNotAllowed(
                 'Some or all wavelength values are not in binset.')
         y = self.binflux[i]
-        return units.convert_flux(x, y, flux_unit, **kwargs)
+
+        if flux_unit is None:
+            flux = y
+        else:
+            flux = units.convert_flux(x, y, flux_unit, **kwargs)
+
+        return flux
 
     def _get_binned_arrays(self, wavelengths, flux_unit, area=None,
                            vegaspec=None):
@@ -395,7 +401,7 @@ class Observation(BaseSourceSpectrum):
 
         return eff_lam * self._internal_wave_unit
 
-    def effstim(self, flux_unit=units.PHOTLAM, wavelengths=None, binned=False,
+    def effstim(self, flux_unit=None, wavelengths=None, binned=False,
                 area=None, vegaspec=None, waverange=None, force=False):
         """Calculate :ref:`effective stimulus <synphot-formula-effstim>`.
 
@@ -404,9 +410,10 @@ class Observation(BaseSourceSpectrum):
 
         Parameters
         ----------
-        flux_unit : str or `~astropy.units.core.Unit`
+        flux_unit : str or `~astropy.units.core.Unit` or `None`
             The unit of effective stimulus.
             COUNT gives result in count/s.
+            If not given, internal unit is used.
 
         wavelengths : array-like, `~astropy.units.quantity.Quantity`, or `None`
             Wavelength values for sampling.
@@ -449,6 +456,9 @@ class Observation(BaseSourceSpectrum):
             Calculation failed.
 
         """
+        if flux_unit is None:
+            flux_unit = self._internal_flux_unit
+
         flux_unit = units.validate_unit(flux_unit)
         flux_unit_name = flux_unit.to_string()
 
@@ -595,8 +605,8 @@ class Observation(BaseSourceSpectrum):
             flux_unit=u.count, wavelengths=wavelengths, binned=binned,
             area=area, waverange=waverange, force=force)
 
-    def plot(self, binned=True, wavelengths=None, flux_unit=units.PHOTLAM,
-             area=None, vegaspec=None, **kwargs):  # pragma: no cover
+    def plot(self, binned=True, wavelengths=None, flux_unit=None, area=None,
+             vegaspec=None, **kwargs):  # pragma: no cover
         """Plot the observation.
 
         .. note:: Uses ``matplotlib``.
@@ -613,8 +623,9 @@ class Observation(BaseSourceSpectrum):
             If `None`, ``self.waveset`` or `binset` is used, depending
             on ``binned``.
 
-        flux_unit : str or `~astropy.units.core.Unit`
+        flux_unit : str or `~astropy.units.core.Unit` or `None`
             Flux is converted to this unit for plotting.
+            If not given, internal unit is used.
 
         area, vegaspec
             See :func:`~synphot.units.convert_flux`.

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -632,8 +632,8 @@ class Observation(BaseSourceSpectrum):
             w, y = self._get_binned_arrays(wavelengths, flux_unit, area=area,
                                            vegaspec=vegaspec)
         else:
-            w, y = self._get_arrays(wavelengths, flux_unit, area=area,
-                                    vegaspec=vegaspec)
+            w, y = self._get_arrays(wavelengths, flux_unit=flux_unit,
+                                    area=area, vegaspec=vegaspec)
         self._do_plot(w, y, **kwargs)
 
     def as_spectrum(self, binned=True, wavelengths=None):
@@ -669,7 +669,8 @@ class Observation(BaseSourceSpectrum):
             w, y = self._get_binned_arrays(
                 wavelengths, self._internal_flux_unit)
         else:
-            w, y = self._get_arrays(wavelengths, self._internal_flux_unit)
+            w, y = self._get_arrays(
+                wavelengths, flux_unit=self._internal_flux_unit)
 
         header = {'observation': str(self), 'binned': binned}
         return SourceSpectrum(Empirical1D, x=w, y=y, meta={'header': header})

--- a/synphot/spectrum.py
+++ b/synphot/spectrum.py
@@ -954,7 +954,7 @@ class BaseSourceSpectrum(BaseSpectrum):
             if band is None:
                 # TODO: Cannot get this to agree with results
                 # from using a very large box bandpass.
-                #stdflux = stdspec.integrate(wavelengths=w).value  # noqa
+                # stdflux = stdspec.integrate(wavelengths=w).value
                 raise NotImplementedError('Must provide a bandpass')
             else:
                 up = stdspec * band

--- a/synphot/spectrum.py
+++ b/synphot/spectrum.py
@@ -382,7 +382,7 @@ class BaseSpectrum(object):
         """Divide self by other."""
         raise NotImplementedError('This operation is not supported.')
 
-    def __div__(self, other):
+    def __div__(self, other):  # pragma: no cover
         """Same as :func:`__truediv__`."""
         return self.__truediv__(other)
 
@@ -930,7 +930,7 @@ class BaseSourceSpectrum(BaseSpectrum):
         if (renorm_val.unit == u.count or
                 renorm_unit_name == units.OBMAG.to_string()):
             # Special handling for non-density units
-            flux_tmp = units.convert_flux(w, sp(w), u.count, area=area)
+            flux_tmp = sp(w, flux_unit=u.count, area=area)
             totalflux = flux_tmp.sum()
             stdflux = 1.0
         else:
@@ -952,7 +952,10 @@ class BaseSourceSpectrum(BaseSpectrum):
                     ConstFlux1D, amplitude=1*renorm_val.unit)
 
             if band is None:
-                stdflux = stdspec.integrate(wavelengths=w).value
+                # TODO: Cannot get this to agree with results
+                # from using a very large box bandpass.
+                #stdflux = stdspec.integrate(wavelengths=w).value  # noqa
+                raise NotImplementedError('Must provide a bandpass')
             else:
                 up = stdspec * band
                 stdflux = up.integrate(wavelengths=wavelengths).value
@@ -1220,7 +1223,7 @@ class BaseUnitlessSpectrum(BaseSpectrum):
         return self._process_generic_param(pval, self._internal_flux_unit)
 
     @staticmethod
-    def _validate_flux_unit(new_unit):
+    def _validate_flux_unit(new_unit):  # pragma: no cover
         """Make sure flux unit is valid."""
         new_unit = units.validate_unit(new_unit)
 

--- a/synphot/tests/test_observation.py
+++ b/synphot/tests/test_observation.py
@@ -266,7 +266,7 @@ class TestObsPar(object):
         ('flux_unit', 'ans'),
         [(units.FLAM, 3.05E-14),
          (units.FNU, 2.92E-25),
-         (units.PHOTLAM, 0.008245),
+         (None, 0.008245),
          (units.PHOTNU, 7.82E-14),
          (u.count, 101462.5),
          (u.Jy, 0.029196),

--- a/synphot/tests/test_spectrum.py
+++ b/synphot/tests/test_spectrum.py
@@ -131,7 +131,7 @@ class TestEmpiricalSourceFromFile(object):
 
     def test_conversion(self):
         x = 0.60451641 * u.micron
-        w, y = self.sp._get_arrays(x, units.FNU)
+        w, y = self.sp._get_arrays(x, flux_unit=units.FNU)
         np.testing.assert_allclose(x.value, w.value)
         np.testing.assert_allclose(y.value, 2.282950185743497e-26, rtol=1e-6)
 
@@ -152,7 +152,7 @@ class TestEmpiricalSourceFromFile(object):
         # Tapering is done
         sp2 = SourceSpectrum(Empirical1D, x=_wave, y=_flux_photlam)
         sp = sp2.taper()
-        x, y = sp._get_arrays(None, units.FLAM)
+        x, y = sp._get_arrays(None, flux_unit=units.FLAM)
         np.testing.assert_allclose(
             x.value, [4954.05152484, 4956.8, 4959.55, 4962.3, 4965.05152484])
         np.testing.assert_allclose(

--- a/synphot/tests/test_spectrum.py
+++ b/synphot/tests/test_spectrum.py
@@ -106,6 +106,15 @@ class TestEmpiricalSourceFromFile(object):
         with pytest.raises(exceptions.SynphotError):
             sp = SourceSpectrum(Empirical1D, x=_wave, y=_flux_vegamag)
 
+    def test_invalid_models(self):
+        # Test not a Model subclass
+        with pytest.raises(exceptions.SynphotError):
+            sp = SourceSpectrum(fits.HDUList)
+
+        # Test unsupported model
+        with pytest.raises(exceptions.SynphotError):
+            sp = SourceSpectrum(RedshiftScaleFactor)
+
     def test_metadata(self):
         assert 'SourceSpectrum' in str(self.sp)
         assert self.sp.meta['header']['SIMPLE']  # From FITS header
@@ -300,6 +309,11 @@ class TestBoxBandpass(object):
         np.testing.assert_allclose(self.bp.fwhm().value, 67.977,
                                    rtol=1e-3)  # 0.1%
 
+    def test_taper(self):
+        bp2 = self.bp.taper(np.arange(499, 501.01, 0.01) * u.nm)
+        y = bp2([498.9, 499, 500, 501, 501.1] * u.nm)
+        np.testing.assert_allclose(y.value, [0, 1, 1, 1, 0])
+
     def test_multi_n_models(self):
         """This is not allowed."""
         with pytest.raises(exceptions.SynphotError):
@@ -364,6 +378,12 @@ class TestPowerLawSource(object):
     def setup_class(self):
         self.sp = SourceSpectrum(PowerLawFlux1D, amplitude=1, x_0=6000,
                                  alpha=4)
+
+    def test_no_default_wave(self):
+        assert self.sp.waverange == [None, None]
+
+        with pytest.raises(exceptions.SynphotError):
+            self.sp(None)
 
     def test_eval(self):
         w = np.arange(3000, 3100, 10)
@@ -577,7 +597,7 @@ class TestNormalize(object):
                              vegaspec=_vspec)
         self._compare_countrate(rn_sp, ans_countrate)
 
-    def test_renorm_noband(self):
+    def test_renorm_noband_count(self):
         """No bandpass. This option is not offered by ASTROLIB PYSYNPHOT
         but can be indirectly calculated using a very large box as bandpass.
 
@@ -586,6 +606,19 @@ class TestNormalize(object):
         x = rn_sp.integrate(flux_unit=u.ct, area=_area)
         ans = 10.615454634451927
         np.testing.assert_allclose(x.value, ans, rtol=1e-3)
+
+    def test_renorm_noband_jy(self):
+        """Replace this with real test when it is implemented."""
+        with pytest.raises(NotImplementedError):
+            rn_sp = self.em.normalize(1e-23 * u.Jy)
+
+    def test_renorm_partial_most(self):
+        """Test 'partial_most' overlap."""
+        bp = SpectralElement(Box1D, amplitude=1, x_0=5600, width=970)
+        rn_sp = self.em.normalize(1e-23 * u.Jy, band=bp)
+        assert 'PartialRenorm' in rn_sp.warnings
+        assert 'PartialRenorm' not in self.em.warnings
+        assert '99%' in rn_sp.warnings['PartialRenorm']
 
     def test_exceptions(self):
         # Invalid passband


### PR DESCRIPTION
`__call__` now can handle flux unit conversion. Default flux unit now ties directly to internal flux unit (but does not change existing behavior). Also, some code clean up. 