### PR TITLE
Implement extrapolation that is like ASTROLIB PYSYNPHOT

### DIFF
--- a/synphot/reddening.py
+++ b/synphot/reddening.py
@@ -5,6 +5,9 @@ from __future__ import absolute_import, division, print_function
 # STDLIB
 import numbers
 
+# THIRD-PARTY
+import numpy as np
+
 # ASTROPY
 from astropy import units as u
 
@@ -69,7 +72,7 @@ class ReddeningLaw(BaseUnitlessSpectrum):
 
         return ExtinctionCurve(
             Empirical1D, points=x, lookup_table=y, meta={'header': header},
-            fill_value=None)
+            fill_value=np.nan)
 
     def to_fits(self, filename, wavelengths=None, **kwargs):
         """Write the reddening law to a FITS file.
@@ -148,7 +151,7 @@ class ReddeningLaw(BaseUnitlessSpectrum):
         header, wavelengths, rvs = specio.read_spec(filename, **kwargs)
 
         return cls(Empirical1D, points=wavelengths, lookup_table=rvs,
-                   meta={'header': header}, fill_value=None)
+                   meta={'header': header}, fill_value=np.nan)
 
     @classmethod
     def from_extinction_model(cls, modelname, **kwargs):
@@ -212,7 +215,7 @@ class ReddeningLaw(BaseUnitlessSpectrum):
         meta = {'header': header, 'expr': modelname}
 
         return cls(Empirical1D, points=wavelengths, lookup_table=rvs,
-                   meta=meta, fill_value=None)
+                   meta=meta, fill_value=np.nan)
 
 
 class ExtinctionCurve(BaseUnitlessSpectrum):

--- a/synphot/spectrum.py
+++ b/synphot/spectrum.py
@@ -650,8 +650,7 @@ class BaseSpectrum(object):
         """
         # We use _model here in case the spectrum is redshifted.
         if isinstance(self._model, Empirical1D):
-            self._model.method = 'nearest'
-            self._model.fill_value = None
+            self._model.fill_value = np.nan
             is_forced = True
         else:
             is_forced = False

--- a/synphot/tests/test_models.py
+++ b/synphot/tests/test_models.py
@@ -118,8 +118,7 @@ class TestEmpirical1D(object):
         y = units.convert_flux(x, f, units.PHOTLAM)
         self.flux_flam = f.value
         self.w = x.value
-        self.m = Empirical1D(
-            points=self.w, lookup_table=y.value, method='linear')
+        self.m = Empirical1D(points=self.w, lookup_table=y.value)
 
     def test_sampleset(self):
         np.testing.assert_array_equal(self.m.sampleset(), self.w)
@@ -181,6 +180,18 @@ class TestEmpirical1D(object):
     def test_taper(self, tab, ans):
         m2 = Empirical1D(points=[1, 2, 3], lookup_table=tab)
         assert m2.is_tapered() is ans
+
+    def test_extrap(self):
+        """Test extrapolation of constant at both ends, as done in
+        ASTROLIB PYSYNPHOT.
+        """
+        m2 = Empirical1D(
+            points=[1000, 2000, 3000, 4000],
+            lookup_table=[0.01, 5.0, 10.6, 1.5], fill_value=np.nan)
+        assert m2(900) == 0.01
+        assert m2(10000) == 1.5
+        np.testing.assert_allclose(
+            m2([900, 1000, 1500, 10000]), [0.01, 0.01, 2.505, 1.5])
 
 
 class TestPowerLawFlux1D(object):

--- a/synphot/tests/test_spectrum.py
+++ b/synphot/tests/test_spectrum.py
@@ -791,7 +791,7 @@ class TestMathOperators(object):
             lookup_table=[0, 3.5e-14, 4e-14, 4.5e-14, 0] * units.FLAM)
         self.sp_2 = SourceSpectrum(
             Empirical1D, points=_wave, lookup_table=_flux_jy,
-            fill_value=None, method='nearest',
+            fill_value=np.nan,
             meta={'PHOTLAM': [9.7654e-3, 1.003896e-2, 9.78473e-3]})
         self.bp_1 = SpectralElement(
             Empirical1D, points=[399.99, 400.01, 500.0, 590.0, 600.1] * u.nm,


### PR DESCRIPTION
Implement extrapolation that is like ASTROLIB PYSYNPHOT. It requires Scipy's `interpn` to behave like `(method='nearest', fill_value=None)` *but* only for extrapolated values, not interpolated values (`method='linear'`).