### PR TITLE
Deprecate EFFLPHOT properly

### DIFF
--- a/synphot/__init__.py
+++ b/synphot/__init__.py
@@ -14,6 +14,8 @@ from ._astropy_init import *
 # For egg_info test builds to pass, put package imports here.
 if not _ASTROPY_SETUP_:
     # SYNPHOT UI
+    from .utils import generate_wavelengths
+    from .models import *
     from .observation import *
     from .reddening import *
     from .thermal import *

--- a/synphot/conftest.py
+++ b/synphot/conftest.py
@@ -7,7 +7,7 @@ from astropy.tests.pytest_plugins import *
 
 # Uncomment the following line to treat all DeprecationWarnings as
 # exceptions
-enable_deprecations_as_exceptions()
+# enable_deprecations_as_exceptions()
 
 # Uncomment and customize the following lines to add/remove entries
 # from the list of packages for which version numbers are displayed

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -14,7 +14,8 @@ import numpy as np
 # ASTROPY
 from astropy import log
 from astropy import units as u
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import (AstropyUserWarning,
+                                      AstropyDeprecationWarning)
 
 # LOCAL
 from . import binning, exceptions, units, utils
@@ -372,7 +373,7 @@ class Observation(BaseSourceSpectrum):
             Flux is first converted to the unit below before calculation:
 
                 * 'efflerg' - FLAM
-                * 'efflphot' - PHOTLAM (depreciated)
+                * 'efflphot' - PHOTLAM (deprecated)
 
         Returns
         -------
@@ -390,7 +391,7 @@ class Observation(BaseSourceSpectrum):
             flux_unit = units.FLAM
         elif mode == 'efflphot':
             warnings.warn(
-                'Usage of EFFLPHOT is depreciated.', AstropyUserWarning)
+                'Usage of EFFLPHOT is deprecated.', AstropyDeprecationWarning)
             flux_unit = units.PHOTLAM
         else:
             raise exceptions.SynphotError(


### PR DESCRIPTION
Deprecate EFFLPHOT properly. Import models and genwave util to synphot namespace.