### PR TITLE
Replaced clobber with overwrite

### DIFF
--- a/synphot/specio.py
+++ b/synphot/specio.py
@@ -218,7 +218,7 @@ def read_fits_spec(filename, ext=1, wave_col='WAVELENGTH', flux_col='FLUX',
 
 
 def write_fits_spec(filename, wavelengths, fluxes, pri_header={},
-                    ext_header={}, clobber=False, trim_zero=True,
+                    ext_header={}, overwrite=False, trim_zero=True,
                     pad_zero_ends=True, precision=None, epsilon=0.00032,
                     wave_col='WAVELENGTH', flux_col='FLUX',
                     wave_unit=u.AA, flux_unit=units.FLAM):
@@ -241,7 +241,7 @@ def write_fits_spec(filename, wavelengths, fluxes, pri_header={},
         Metadata to be added to primary and given extension FITS header,
         respectively. Do *not* use this to define column names and units.
 
-    clobber : bool
+    overwrite : bool
         Overwrite existing file. Defaults to `False`.
 
     trim_zero : bool
@@ -383,4 +383,4 @@ def write_fits_spec(filename, wavelengths, fluxes, pri_header={},
     # Write to file
     hdulist = fits.HDUList([hdr_hdu])
     hdulist.append(tab_hdu)
-    hdulist.writeto(filename, clobber=clobber)
+    hdulist.writeto(filename, overwrite=overwrite)

--- a/synphot/tests/test_reddening.py
+++ b/synphot/tests/test_reddening.py
@@ -112,9 +112,9 @@ class TestWriteReddeningLaw(object):
         outfile = os.path.join(self.outdir, 'outredlaw.fits')
 
         if ext_hdr is None:
-            self.redlaw.to_fits(outfile, clobber=True)
+            self.redlaw.to_fits(outfile, overwrite=True)
         else:
-            self.redlaw.to_fits(outfile, clobber=True, ext_header=ext_hdr)
+            self.redlaw.to_fits(outfile, overwrite=True, ext_header=ext_hdr)
 
         # Read it back in and check
         redlaw2 = ReddeningLaw.from_file(outfile)

--- a/synphot/tests/test_specio.py
+++ b/synphot/tests/test_specio.py
@@ -141,17 +141,17 @@ class TestReadWriteFITS(object):
         # Invalid precision keyword
         with pytest.raises(exceptions.SynphotError):
             specio.write_fits_spec(
-                outfile, self.wave, self.flux, precision='foo', clobber=True)
+                outfile, self.wave, self.flux, precision='foo', overwrite=True)
 
         # Invalid wavelength precision
         with pytest.raises(exceptions.SynphotError):
             specio.write_fits_spec(
-                outfile, np.arange(6), self.flux, clobber=True)
+                outfile, np.arange(6), self.flux, overwrite=True)
 
         # Invalid flux precision
         with pytest.raises(exceptions.SynphotError):
             specio.write_fits_spec(
-                outfile, self.wave, np.arange(6), clobber=True)
+                outfile, self.wave, np.arange(6), overwrite=True)
 
     def teardown_class(self):
         shutil.rmtree(self.outdir)

--- a/synphot/tests/test_spectrum.py
+++ b/synphot/tests/test_spectrum.py
@@ -967,10 +967,10 @@ class TestWriteSpec(object):
             sp1 = self.bp
 
         if ext_hdr is None:
-            sp1.to_fits(outfile, clobber=True, trim_zero=False,
+            sp1.to_fits(outfile, overwrite=True, trim_zero=False,
                         pad_zero_ends=False)
         else:
-            sp1.to_fits(outfile, clobber=True, trim_zero=False,
+            sp1.to_fits(outfile, overwrite=True, trim_zero=False,
                         pad_zero_ends=False, ext_header=ext_hdr)
 
         # Read it back in and check


### PR DESCRIPTION
Replaced `clobber` keyword with `overwrite` for FITS I/O to be consistent with Astropy 1.3 and to avoid deprecation warnings.