### PR TITLE
Use system pytest and update astropy-helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,14 @@ env:
         # to repeat them for all configurations.
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
-        #- ASTROPY_VERSION=stable
-        - ASTROPY_VERSION=development
+        - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
         # For this package-template, we include examples of Cython modules,
         # so Cython is required for testing. If your package does not include
         # Cython code, you can set CONDA_DEPENDENCIES=''
         #- CONDA_DEPENDENCIES='Cython'
-        - CONDA_DEPENDENCIES='Cython jinja2 scipy'
+        - CONDA_DEPENDENCIES='Cython jinja2 scipy pytest'
     matrix:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'
@@ -45,22 +44,19 @@ env:
 matrix:
     include:
 
-        # Do a coverage test in Python 2.
-        - python: 2.7
+        # Do a coverage test in Python 3.
+        - python: 3.5
           env: SETUP_CMD='test --coverage'
 
         # DISABLED FOR NOW
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
-        #- python: 2.7
+        #- python: 3.5
         #  env: SETUP_CMD='build_sphinx -w'
 
-        # DISABLED FOR NOW
         # Try Astropy development version
-        #- python: 2.7
-        #  env: ASTROPY_VERSION=development
-        #- python: 3.5
-        #  env: ASTROPY_VERSION=development
+        - python: 3.6
+          env: ASTROPY_VERSION=development
 
         # Do a PEP8 test with pycodestyle
         - python: 3.5
@@ -87,7 +83,7 @@ install:
     # commands in the install: section below.
 
     - git clone git://github.com/astropy/ci-helpers.git
-    - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
+    - source ci-helpers/travis/setup_conda.sh
 
     # Upgrade to the latest version of pip to avoid it displaying warnings
     # about it being out of date.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,13 +18,13 @@ environment:
 
   matrix:
 
-      # We test Python 2.7 and 3.5
+      # We test Python 2.7 and 3.6
 
       - PYTHON_VERSION: "2.7"
-        ASTROPY_VERSION: "development"
+        ASTROPY_VERSION: "stable"
         NUMPY_VERSION: "stable"
 
-      - PYTHON_VERSION: "3.5"
+      - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "development"
         NUMPY_VERSION: "stable"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,8 +7,8 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-[pytest]
-minversion = 2.2
+[tool:pytest]
+minversion = 3.0
 norecursedirs = build docs/_build synphot/src
 
 [ah_bootstrap]

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,7 @@ setup(name=PACKAGENAME,
       description=DESCRIPTION,
       scripts=scripts,
       install_requires=['numpy', 'astropy'],  # 'numpy>=1.9', 'astropy>=1.3', 'scipy>=0.14'
+      tests_require=['pytest'],
       author=AUTHOR,
       author_email=AUTHOR_EMAIL,
       license=LICENSE,

--- a/synphot/_astropy_init.py
+++ b/synphot/_astropy_init.py
@@ -140,5 +140,5 @@ if not _ASTROPY_SETUP_:  # noqa
                             "expected.")
                     warn(ConfigurationDefaultMissingWarning(wmsg))
                     del e
-                except:
+                except Exception:
                     raise orig_error

--- a/synphot/tests/test_binning.py
+++ b/synphot/tests/test_binning.py
@@ -8,10 +8,10 @@ import warnings
 
 # THIRD PARTY
 import numpy as np
+import pytest
 
 # ASTROPY
 from astropy import units as u
-from astropy.tests.helper import pytest
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
 

--- a/synphot/tests/test_models.py
+++ b/synphot/tests/test_models.py
@@ -16,10 +16,10 @@ import os
 
 # THIRD-PARTY
 import numpy as np
+import pytest
 
 # ASTROPY
 from astropy import units as u
-from astropy.tests.helper import pytest
 from astropy.utils import minversion
 from astropy.utils.data import get_pkg_data_filename
 

--- a/synphot/tests/test_observation.py
+++ b/synphot/tests/test_observation.py
@@ -12,9 +12,10 @@ import pytest
 # ASTROPY
 from astropy import units as u
 from astropy.modeling.models import Const1D
-from astropy.tests.helper import remote_data
+from astropy.tests.helper import remote_data, catch_warnings
 from astropy.utils import minversion
 from astropy.utils.data import get_pkg_data_filename
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 # LOCAL
 from .test_units import _area
@@ -249,17 +250,20 @@ class TestObsPar(object):
         np.testing.assert_allclose(
             obs2.countrate(_area).value, 59517756.384, rtol=1e-5)
 
-    @pytest.mark.parametrize(
-        ('mode', 'ans'),
-        [('efflerg', 5321.091),
-         ('efflphot', 5344.312)])
-    def test_efflam(self, mode, ans):
+    @pytest.mark.parametrize('binned', [True, False])
+    def test_efflam(self, binned):
+        with catch_warnings(AstropyDeprecationWarning) as w:
+            x = self.obs.effective_wavelength(mode='efflphot', binned=binned)
+            assert len(w) == 1
+            assert str(w[0].message) == 'Usage of EFFLPHOT is deprecated.'
+
+        np.testing.assert_allclose(x.value, 5344.312, rtol=1e-4)
+
+    @pytest.mark.parametrize('binned', [True, False])
+    def test_efflam_erg(self, binned):
         np.testing.assert_allclose(
-            self.obs.effective_wavelength(mode=mode, binned=False).value,
-            ans, rtol=1e-4)
-        np.testing.assert_allclose(
-            self.obs.effective_wavelength(mode=mode, binned=True).value,
-            ans, rtol=1e-4)
+            self.obs.effective_wavelength(mode='efflerg', binned=binned).value,
+            5321.091, rtol=1e-4)
 
     def test_efflam_exception(self):
         with pytest.raises(exceptions.SynphotError):

--- a/synphot/tests/test_observation.py
+++ b/synphot/tests/test_observation.py
@@ -7,11 +7,12 @@ import os
 
 # THIRD-PARTY
 import numpy as np
+import pytest
 
 # ASTROPY
 from astropy import units as u
 from astropy.modeling.models import Const1D
-from astropy.tests.helper import pytest, remote_data
+from astropy.tests.helper import remote_data
 from astropy.utils import minversion
 from astropy.utils.data import get_pkg_data_filename
 

--- a/synphot/tests/test_reddening.py
+++ b/synphot/tests/test_reddening.py
@@ -9,11 +9,12 @@ import tempfile
 
 # THIRD-PARTY
 import numpy as np
+import pytest
 
 # ASTROPY
 from astropy import units as u
 from astropy.io import fits
-from astropy.tests.helper import pytest, remote_data
+from astropy.tests.helper import remote_data
 from astropy.utils import minversion
 from astropy.utils.data import get_pkg_data_filename
 

--- a/synphot/tests/test_specio.py
+++ b/synphot/tests/test_specio.py
@@ -9,11 +9,12 @@ import tempfile
 
 # THIRD-PARTY
 import numpy as np
+import pytest
 
 # ASTROPY
 from astropy import units as u
 from astropy.io import fits
-from astropy.tests.helper import pytest, remote_data
+from astropy.tests.helper import remote_data
 from astropy.utils.data import get_pkg_data_filename
 
 # LOCAL

--- a/synphot/tests/test_spectrum.py
+++ b/synphot/tests/test_spectrum.py
@@ -9,6 +9,7 @@ import tempfile
 
 # THIRD-PARTY
 import numpy as np
+import pytest
 
 # ASTROPY
 from astropy import modeling
@@ -17,7 +18,7 @@ from astropy.io import fits
 from astropy.modeling.models import (
     BrokenPowerLaw1D, Const1D, ExponentialCutoffPowerLaw1D, LogParabola1D,
     PowerLaw1D, RedshiftScaleFactor)
-from astropy.tests.helper import pytest, remote_data
+from astropy.tests.helper import remote_data
 from astropy.utils import minversion
 from astropy.utils.data import get_pkg_data_filename
 

--- a/synphot/tests/test_thermal.py
+++ b/synphot/tests/test_thermal.py
@@ -7,10 +7,10 @@ import os
 
 # THIRD-PARTY
 import numpy as np
+import pytest
 
 # ASTROPY
 from astropy import units as u
-from astropy.tests.helper import pytest
 from astropy.utils import minversion
 from astropy.utils.data import get_pkg_data_filename
 

--- a/synphot/tests/test_units.py
+++ b/synphot/tests/test_units.py
@@ -8,10 +8,10 @@ from __future__ import absolute_import, division, print_function
 
 # THIRD-PARTY
 import numpy as np
+import pytest
 
 # ASTROPY
 from astropy import units as u
-from astropy.tests.helper import pytest
 
 # LOCAL
 from .. import exceptions, units

--- a/synphot/tests/test_utils.py
+++ b/synphot/tests/test_utils.py
@@ -5,10 +5,10 @@ from ..extern import six
 
 # THIRD PARTY
 import numpy as np
+import pytest
 
 # ASTROPY
 from astropy import units as u
-from astropy.tests.helper import pytest
 
 # LOCAL
 from .. import exceptions, utils


### PR DESCRIPTION
Use system `pytest` and update `astropy-helpers`. Will need a release to include this fix for Astropy v2.