### PR TITLE
Fix failed tests due to Astropy constants update

### DIFF
--- a/synphot/tests/test_models.py
+++ b/synphot/tests/test_models.py
@@ -41,7 +41,7 @@ ASTROPY_LT_20 = not minversion(astropy, '2.0')
 
 def setup_module(module):
     # https://github.com/astropy/astropy/issues/6383
-    if ASTROPY_LT_20:
+    if not ASTROPY_LT_20:
         import astropy.constants as const
         from astropy.constants import si, astropyconst13
 
@@ -52,7 +52,7 @@ def setup_module(module):
 
 def teardown_module(module):
     # https://github.com/astropy/astropy/issues/6383
-    if ASTROPY_LT_20:
+    if not ASTROPY_LT_20:
         import astropy.constants as const
         from astropy.constants import si, astropyconst20
         const.sigma_sb = si.sigma_sb = astropyconst20.sigma_sb

--- a/synphot/tests/test_models.py
+++ b/synphot/tests/test_models.py
@@ -19,6 +19,7 @@ import numpy as np
 import pytest
 
 # ASTROPY
+import astropy
 from astropy import units as u
 from astropy.utils import minversion
 from astropy.utils.data import get_pkg_data_filename
@@ -35,6 +36,28 @@ else:
     HAS_SCIPY = True
 
 HAS_SCIPY = HAS_SCIPY and minversion(scipy, '0.14')
+ASTROPY_LT_20 = not minversion(astropy, '2.0')
+
+
+def setup_module(module):
+    # https://github.com/astropy/astropy/issues/6383
+    if ASTROPY_LT_20:
+        import astropy.constants as const
+        from astropy.constants import si, astropyconst13
+
+        const.sigma_sb = si.sigma_sb = astropyconst13.sigma_sb
+        const.h = si.h = astropyconst13.h
+        const.k_B = si.k_B = astropyconst13.k_B
+
+
+def teardown_module(module):
+    # https://github.com/astropy/astropy/issues/6383
+    if ASTROPY_LT_20:
+        import astropy.constants as const
+        from astropy.constants import si, astropyconst20
+        const.sigma_sb = si.sigma_sb = astropyconst20.sigma_sb
+        const.h = si.sigma.h = astropyconst20.h
+        const.k_B = si.k_B = astropyconst20.k_B
 
 
 class TestBlackBody1D(object):

--- a/synphot/tests/test_models.py
+++ b/synphot/tests/test_models.py
@@ -56,7 +56,7 @@ def teardown_module(module):
         import astropy.constants as const
         from astropy.constants import si, astropyconst20
         const.sigma_sb = si.sigma_sb = astropyconst20.sigma_sb
-        const.h = si.sigma.h = astropyconst20.h
+        const.h = si.h = astropyconst20.h
         const.k_B = si.k_B = astropyconst20.k_B
 
 

--- a/synphot/tests/test_spectrum.py
+++ b/synphot/tests/test_spectrum.py
@@ -64,7 +64,7 @@ def teardown_module(module):
         import astropy.constants as const
         from astropy.constants import si, astropyconst20
         const.sigma_sb = si.sigma_sb = astropyconst20.sigma_sb
-        const.h = si.sigma.h = astropyconst20.h
+        const.h = si.h = astropyconst20.h
         const.k_B = si.k_B = astropyconst20.k_B
 
 

--- a/synphot/tests/test_spectrum.py
+++ b/synphot/tests/test_spectrum.py
@@ -12,6 +12,7 @@ import numpy as np
 import pytest
 
 # ASTROPY
+import astropy
 from astropy import modeling
 from astropy import units as u
 from astropy.io import fits
@@ -40,9 +41,31 @@ else:
     HAS_SCIPY = True
 
 HAS_SCIPY = HAS_SCIPY and minversion(scipy, '0.14')
+ASTROPY_LT_20 = not minversion(astropy, '2.0')
 
 # GLOBAL VARIABLES
 _vspec = None  # Loaded in test_load_vspec()
+
+
+def setup_module(module):
+    # https://github.com/astropy/astropy/issues/6383
+    if ASTROPY_LT_20:
+        import astropy.constants as const
+        from astropy.constants import si, astropyconst13
+
+        const.sigma_sb = si.sigma_sb = astropyconst13.sigma_sb
+        const.h = si.h = astropyconst13.h
+        const.k_B = si.k_B = astropyconst13.k_B
+
+
+def teardown_module(module):
+    # https://github.com/astropy/astropy/issues/6383
+    if ASTROPY_LT_20:
+        import astropy.constants as const
+        from astropy.constants import si, astropyconst20
+        const.sigma_sb = si.sigma_sb = astropyconst20.sigma_sb
+        const.h = si.sigma.h = astropyconst20.h
+        const.k_B = si.k_B = astropyconst20.k_B
 
 
 @remote_data

--- a/synphot/tests/test_spectrum.py
+++ b/synphot/tests/test_spectrum.py
@@ -49,7 +49,7 @@ _vspec = None  # Loaded in test_load_vspec()
 
 def setup_module(module):
     # https://github.com/astropy/astropy/issues/6383
-    if ASTROPY_LT_20:
+    if not ASTROPY_LT_20:
         import astropy.constants as const
         from astropy.constants import si, astropyconst13
 
@@ -60,7 +60,7 @@ def setup_module(module):
 
 def teardown_module(module):
     # https://github.com/astropy/astropy/issues/6383
-    if ASTROPY_LT_20:
+    if not ASTROPY_LT_20:
         import astropy.constants as const
         from astropy.constants import si, astropyconst20
         const.sigma_sb = si.sigma_sb = astropyconst20.sigma_sb

--- a/synphot/tests/test_thermal.py
+++ b/synphot/tests/test_thermal.py
@@ -47,7 +47,7 @@ def teardown_module(module):
         import astropy.constants as const
         from astropy.constants import si, astropyconst20
         const.sigma_sb = si.sigma_sb = astropyconst20.sigma_sb
-        const.h = si.sigma.h = astropyconst20.h
+        const.h = si.h = astropyconst20.h
         const.k_B = si.k_B = astropyconst20.k_B
 
 

--- a/synphot/tests/test_thermal.py
+++ b/synphot/tests/test_thermal.py
@@ -32,7 +32,7 @@ ASTROPY_LT_20 = not minversion(astropy, '2.0')
 
 def setup_module(module):
     # https://github.com/astropy/astropy/issues/6383
-    if ASTROPY_LT_20:
+    if not ASTROPY_LT_20:
         import astropy.constants as const
         from astropy.constants import si, astropyconst13
 
@@ -43,7 +43,7 @@ def setup_module(module):
 
 def teardown_module(module):
     # https://github.com/astropy/astropy/issues/6383
-    if ASTROPY_LT_20:
+    if not ASTROPY_LT_20:
         import astropy.constants as const
         from astropy.constants import si, astropyconst20
         const.sigma_sb = si.sigma_sb = astropyconst20.sigma_sb

--- a/synphot/tests/test_thermal.py
+++ b/synphot/tests/test_thermal.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 # ASTROPY
+import astropy
 from astropy import units as u
 from astropy.utils import minversion
 from astropy.utils.data import get_pkg_data_filename
@@ -26,6 +27,28 @@ else:
     HAS_SCIPY = True
 
 HAS_SCIPY = HAS_SCIPY and minversion(scipy, '0.14')
+ASTROPY_LT_20 = not minversion(astropy, '2.0')
+
+
+def setup_module(module):
+    # https://github.com/astropy/astropy/issues/6383
+    if ASTROPY_LT_20:
+        import astropy.constants as const
+        from astropy.constants import si, astropyconst13
+
+        const.sigma_sb = si.sigma_sb = astropyconst13.sigma_sb
+        const.h = si.h = astropyconst13.h
+        const.k_B = si.k_B = astropyconst13.k_B
+
+
+def teardown_module(module):
+    # https://github.com/astropy/astropy/issues/6383
+    if ASTROPY_LT_20:
+        import astropy.constants as const
+        from astropy.constants import si, astropyconst20
+        const.sigma_sb = si.sigma_sb = astropyconst20.sigma_sb
+        const.h = si.sigma.h = astropyconst20.h
+        const.k_B = si.k_B = astropyconst20.k_B
 
 
 @pytest.mark.skipif('not HAS_SCIPY')


### PR DESCRIPTION
Fix #125 

Use old constants for tests to maintain backward compatibility with `astrolib` results. This is using the recommended solution in astropy/astropy#6383.