### PR TITLE
Make effstim calculation consistent with PySynphot

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@
 
 - Config to use HTTP instead of FTP. [#171]
 - Fixed scalar unit conversion for VEGAMAG. [#174]
+- Bug fix for ``effstim`` calculations in some flux units. [#159, #166]
 
 0.1.2 (2018-07-19)
 ==================

--- a/docs/synphot/formulae.rst
+++ b/docs/synphot/formulae.rst
@@ -283,14 +283,16 @@ The default binning behavior is to be consistent with ASTROLIB PYSYNPHOT.
 
 Example::
 
-    >>> obs.effstim()  # Not binned
-    <Quantity 0.00054170149051543 PHOTLAM>
+    >>> obs.effstim()
+    <Quantity 0.00053744 PHOTLAM>
     >>> obs.effstim('flam')
-    <Quantity 1.992237048596971e-15 FLAM>
-    >>> obs.effstim('count', area=area, binned=True)  # Binned
-    <Quantity 6624.720529866574 ct / s>
-    >>> obs.countrate(area=area)
-    <Quantity 6624.720529866574 ct / s>
+    <Quantity 1.99333435e-15 FLAM>
+    >>> obs.effstim('count', area=area)  # Not binned
+    <Quantity 6628.36886854 ct / s>
+    >>> obs.countrate(area=area, binned=False)
+    <Quantity 6628.36886854 ct / s>
+    >>> obs.countrate(area=area)  # Binned
+    <Quantity 6628.36888121 ct / s>
 
 
 .. _synphot-formula-effwave:

--- a/docs/synphot/observation.rst
+++ b/docs/synphot/observation.rst
@@ -69,22 +69,18 @@ you can use its :meth:`~synphot.observation.Observation.binned_waverange` and
     10
 
 In addition, it has unique properties such as :ref:`synphot-formula-effstim`
-and :ref:`synphot-formula-effwave`, which can be calculated for either "native"
-or binned sampling, which usually provides similar results regardless.
-The default sampling behaviors are to be consistent with ASTROLIB PYSYNPHOT::
+and :ref:`synphot-formula-effwave`, which can be calculated in a way
+that is consistent with ASTROLIB PYSYNPHOT::
 
-    >>> # Effective stimulus in FLAM for "native" sampling
+    >>> # Effective stimulus in FLAM
     >>> obs.effstim(flux_unit='flam')
-    <Quantity 3.78652304711832e-09 FLAM>
-    >>> # Repeat for binned sampling
-    >>> obs.effstim(flux_unit='flam', binned=True)
-    <Quantity 3.7865234761885156e-09 FLAM>
+    <Quantity 3.78664384e-09 FLAM>
     >>> # Effective wavelength for binned sampling in FLAM
     >>> obs.effective_wavelength()
-    <Quantity 5332.703380347104 Angstrom>
+    <Quantity 5332.62717945 Angstrom>
     >>> # Repeat for "native" sampling
     >>> obs.effective_wavelength(binned=False)
-    <Quantity 5332.703444644624 Angstrom>
+    <Quantity 5332.62724394 Angstrom>
 
 :meth:`~synphot.observation.Observation.countrate` is probably the most often
 used method for an observation.
@@ -95,7 +91,7 @@ one wavelength bin corresponds to one detector pixel::
 
     >>> area = 45238.93416  # HST, in cm^2
     >>> obs.countrate(area)
-    <Quantity 19208895560.359768 ct / s>
+    <Quantity 1.9249653e+10 ct / s>
 
 An observation can be converted to a **regular source spectrum** containing
 only the wavelength set and sampled flux (binned by default) by using its


### PR DESCRIPTION
Fix #159

I can't say I understand why PHOTNU needs a special logic block. I tried converting from PHOTLAM and FLAM using bandpass pivot (like what is done with FNU etc) but it didn't work out. At least all the supported flux units give values consistent with PySynphot now (in my limited testing). 

Results *before* the fix: https://gist.github.com/pllim/2d053b327d384c587b0297950644e7d1

Results *after* the fix: https://gist.github.com/pllim/c378494302ad4df095fe506df8ae8ade

**TODO**

- [x] Wait for resolution of spacetelescope/pysynphot#103 and update this PR, if necessary
- [x] Add/fix tests
- [x] Add change log
- [x] Update examples in doc, if necessary
- [x] Wait for Tyler's feedback

cc @deustua @tddesjardins @bhilbert4 (Tyler, do you want to take this for a spin?)