### PR TITLE
TST: Add [docs only] directive

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,11 +55,13 @@ stages:
         pip install numpy scipy astropy pytest-astropy codecov
         python setup.py test --coverage --open-files --remote-data
       displayName: 'Run tests'
+      condition: not(contains(variables['Build.SourceVersionMessage'], '[docs only]'))
 
     - script: codecov -t $codecov_token
       env:
         codecov_token: $(CODECOV_TOKEN)
       displayName: 'Calculate coverage'
+      condition: not(contains(variables['Build.SourceVersionMessage'], '[docs only]'))
 
   - template: azure-templates.yml
     parameters:

--- a/azure-templates.yml
+++ b/azure-templates.yml
@@ -34,6 +34,7 @@ jobs:
     condition: eq( variables['Agent.OS'], 'Windows_NT' )
     displayName: Set var on Windows
 
+  # Cannot use this for doc build because [docs only] will skip this
   - script: |
       sudo apt-get install libxml2-utils
       python -m pip install --upgrade pip setuptools
@@ -42,3 +43,4 @@ jobs:
       ${{ parameters.astropyCmd }}
       python setup.py test --open-files $(PYTEST_EXTRA_ARGS)
     displayName: 'Run tests'
+    condition: not(contains(variables['Build.SourceVersionMessage'], '[docs only]'))


### PR DESCRIPTION
Inspired by https://github.com/Microsoft/azure-pipelines-agent/issues/858#issuecomment-457027046 . Let's see if this works. Only the "initial" jobs and doc build should run, nothing else.

Attempt to fix #196 