### PR TITLE
MNT: Compatibility with new models in astropy 4.0dev

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,9 +63,10 @@ stages:
 
   - template: azure-templates.yml
     parameters:
-      name: 'LTS_Astropy'
+      name: 'Older_Versions'
       numpyCmd: 'pip install numpy==1.15.4'
       astropyCmd: 'pip install astropy==2.0.12'
+      scipyCmd: 'pip install scipy==1.1.0'
       pythonVersion: '3.6'
 
   - template: azure-templates.yml

--- a/azure-templates.yml
+++ b/azure-templates.yml
@@ -5,6 +5,7 @@ parameters:
   vmImage: 'Ubuntu-16.04'
   numpyCmd: 'pip install numpy'
   astropyCmd: 'pip install astropy'
+  scipyCmd: 'pip install scipy'
   pythonVersion: '3.7'
   pytestExtraArgs: ''
 
@@ -28,6 +29,7 @@ jobs:
     displayName: Set var on Linux/Darwin
 
   # Disable --remote-data for Windows regardless of pytestExtraArgs
+  # due to some problem with parsing the args in powershell
   - powershell: |
       Set-Variable -Name PYTEST_EXTRA_ARGS -Value ''
       Write-Host "##vso[task.setvariable variable=PYTEST_EXTRA_ARGS]$PYTEST_EXTRA_ARGS"
@@ -38,7 +40,8 @@ jobs:
       sudo apt-get install libxml2-utils
       python -m pip install --upgrade pip setuptools
       ${{ parameters.numpyCmd }}
-      pip install scipy pytest-astropy
+      ${{ parameters.scipyCmd }}
+      pip install pytest-astropy
       ${{ parameters.astropyCmd }}
       python setup.py test --open-files $(PYTEST_EXTRA_ARGS)
     displayName: 'Run tests'

--- a/synphot/compat.py
+++ b/synphot/compat.py
@@ -4,6 +4,7 @@
 import astropy
 from astropy.utils.introspection import minversion
 
-__all__ = ['ASTROPY_LT_2_0']
+__all__ = ['ASTROPY_LT_2_0', 'ASTROPY_LT_4_0']
 
 ASTROPY_LT_2_0 = not minversion(astropy, '2.0')
+ASTROPY_LT_4_0 = not minversion(astropy, '4.0')

--- a/synphot/spectrum.py
+++ b/synphot/spectrum.py
@@ -14,15 +14,20 @@ import numpy as np
 from astropy import log
 from astropy import units as u
 from astropy.modeling import Model
-from astropy.modeling.core import _CompoundModel
 from astropy.modeling.models import RedshiftScaleFactor, Scale
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils import metadata
 
 # LOCAL
 from . import exceptions, specio, units, utils
+from .compat import ASTROPY_LT_4_0
 from .config import Conf, conf
 from .models import ConstFlux1D, Empirical1D, get_waveset, get_metadata
+
+if ASTROPY_LT_4_0:
+    from astropy.modeling.core import _CompoundModel as CompoundModel
+else:
+    from astropy.modeling.core import CompoundModel
 
 __all__ = ['BaseSpectrum', 'BaseSourceSpectrum', 'SourceSpectrum',
            'BaseUnitlessSpectrum', 'SpectralElement']
@@ -134,7 +139,7 @@ class BaseSpectrum(object):
         if isinstance(modelclass, Model):
             self._model = modelclass
 
-            if isinstance(modelclass, _CompoundModel):
+            if isinstance(modelclass, CompoundModel):
                 clean_meta = True
 
         elif isinstance(modelclass, BaseSpectrum):
@@ -1418,7 +1423,7 @@ class SpectralElement(BaseUnitlessSpectrum):
             if ((isinstance(other.model, Empirical1D) and
                  other.model.is_tapered() or
                  not isinstance(other.model,
-                                (Empirical1D, _CompoundModel))) and
+                                (Empirical1D, CompoundModel))) and
                     np.allclose(other(x1[::x1.size - 1]).value, 0)):
                 result = 'full'
 

--- a/synphot/tests/test_models.py
+++ b/synphot/tests/test_models.py
@@ -20,12 +20,14 @@ import pytest
 # ASTROPY
 import astropy
 from astropy import units as u
+from astropy.modeling.models import Const1D
 from astropy.utils import minversion
 from astropy.utils.data import get_pkg_data_filename
 
 # LOCAL
 from .. import specio, units
-from ..models import BlackBody1D, ConstFlux1D, Empirical1D, PowerLawFlux1D
+from ..models import (BlackBody1D, ConstFlux1D, Empirical1D, PowerLawFlux1D,
+                      get_metadata)
 
 try:
     import scipy
@@ -257,3 +259,23 @@ class TestPowerLawFlux1D(object):
     def test_invalid_units(self, flux_unit):
         with pytest.raises(NotImplementedError):
             PowerLawFlux1D(amplitude=1 * flux_unit, x_0=5000, alpha=4)
+
+
+def test_get_metadata():
+    m1 = Const1D()
+    m1.meta['description'] = 'a constant'
+    m1.meta['foo'] = 42.0
+
+    m2 = Const1D()
+    m2.meta['description'] = 'another constant'
+
+    m3 = Const1D()
+    m3.meta[42] = 'answer'
+
+    m = (m1 + m2) * m3
+    meta = get_metadata(m)
+    keys = list(meta.keys())
+    assert len(keys) == 3
+    assert meta['description'] == 'another constant'
+    assert meta['foo'] == 42
+    assert meta[42] == 'answer'


### PR DESCRIPTION
Ensure `synphot` still works with astropy/astropy#8769.

**TODO**

- [x] Make tests pass.
- [x] Make sure tests pass for spacetelescope/stsynphot_refactor#81 too (also refactor its Azure jobs like this one)
- [x] Report back to astropy/astropy#8769
- [x] Clean up with only real code changes for compatibility when astropy/astropy#8769 is merged.
- [x] Final check.