### PR TITLE
Adding signal to noise ratio calculations to observation.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,9 +3,9 @@
 
 - Removed Python 2 support. This version is only compatible with Python 3.5
   or later. [#185]
-- New ``synphot.observation.howell_snr()`` function to calculate the signal
+- New ``synphot.observation.ccd_snr()`` function to calculate the signal
   to noise ratio given a count rate and exposure time.
-- New ``synphot.observation.exptime_from_howell_snr()`` function to
+- New ``synphot.observation.exptime_from_ccd_snr()`` function to
   determine the exposure time needed to achieve a given signal to noise
   ratio.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,10 @@
 - Removed Python 2 support. This version is only compatible with Python 3.5
   or later. [#185]
 - New ``synphot.observation.ccd_snr()`` function to calculate the signal
-  to noise ratio given a count rate and exposure time.
+  to noise ratio given a count rate and exposure time. [#204]
 - New ``synphot.observation.exptime_from_ccd_snr()`` function to
   determine the exposure time needed to achieve a given signal to noise
-  ratio.
+  ratio. [#204]
 
 0.1.3 (2019-03-24)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@
 
 - Removed Python 2 support. This version is only compatible with Python 3.5
   or later. [#185]
+- New ``synphot.observation.howell_snr()`` function to calculate the signal
+  to noise ratio given a count rate and exposure time.
+- New ``synphot.observation.exptime_from_howell_snr()`` function to
+  determine the exposure time needed to achieve a given signal to noise
+  ratio.
 
 0.1.3 (2019-03-24)
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -221,9 +221,23 @@ Calculate the count rate of the observation above for an 2-meter telescope:
     >>> area = np.pi * (1 * u.m) ** 2
     >>> area
     <Quantity 3.14159265 m2>
-    >>> obs.countrate(area=area)
+    >>> countrate = obs.countrate(area=area)
+    >>> countrate
     <Quantity 24219651.1854991 ct / s>
 
+Calculate the signal to noise ratio in a 1 second exposure from this count rate:
+
+    >>> from synphot.observation import howell_snr
+    >>> exptime = 1 * u.s
+    >>> howell_snr(countrate * exptime)
+    <Quantity 4921.34644491 ct(1/2)>
+
+Determine the exposure time needed to reach a certain signal to noise ratio:
+
+    >>> from synphot.observation import exptime_from_howell_snr
+    >>> snr = 100 * np.sqrt(1 * u.ct)
+    >>> exptime_from_howell_snr(snr, countrate)
+    <Quantity 0.00041289 s>
 
 .. _synphot_using:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -227,16 +227,16 @@ Calculate the count rate of the observation above for an 2-meter telescope:
 
 Calculate the signal to noise ratio in a 1 second exposure from this count rate:
 
-    >>> from synphot.observation import howell_snr
+    >>> from synphot.observation import ccd_snr
     >>> exptime = 1 * u.s
-    >>> howell_snr(countrate * exptime)
+    >>> ccd_snr(countrate * exptime)
     <Quantity 4921.34644491 ct(1/2)>
 
 Determine the exposure time needed to reach a certain signal to noise ratio:
 
-    >>> from synphot.observation import exptime_from_howell_snr
+    >>> from synphot.observation import exptime_from_ccd_snr
     >>> snr = 100 * np.sqrt(1 * u.ct)
-    >>> exptime_from_howell_snr(snr, countrate)
+    >>> exptime_from_ccd_snr(snr, countrate)
     <Quantity 0.00041289 s>
 
 .. _synphot_using:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -230,12 +230,12 @@ Calculate the signal to noise ratio in a 1 second exposure from this count rate:
     >>> from synphot.observation import ccd_snr
     >>> exptime = 1 * u.s
     >>> ccd_snr(countrate * exptime)
-    <Quantity 4921.34644491 ct(1/2)>
+    <Quantity 4921.34644491>
 
 Determine the exposure time needed to reach a certain signal to noise ratio:
 
     >>> from synphot.observation import exptime_from_ccd_snr
-    >>> snr = 100 * np.sqrt(1 * u.ct)
+    >>> snr = 100
     >>> exptime_from_ccd_snr(snr, countrate)
     <Quantity 0.00041289 s>
 

--- a/docs/synphot/observation.rst
+++ b/docs/synphot/observation.rst
@@ -102,7 +102,7 @@ time::
     >>> import astropy.units as u
     >>> exptime = 1 * u.s
     >>> ccd_snr(countrate * exptime)
-    <Quantity 138743.11880657 ct(1/2)>
+    <Quantity 138743.11880657>
 
 Or, to determine the exposure time needed to reach a certain signal to noise
 ratio, use the :func:`~synphot.observation.exptime_from_ccd_snr`
@@ -110,7 +110,7 @@ function with the observation's count rate::
 
     >>> from synphot.observation import exptime_from_ccd_snr
     >>> import numpy as np
-    >>> snr = 100 * np.sqrt(1 * u.ct)  # desired SNR of 100
+    >>> snr = 100  # desired SNR of 100
     >>> exptime_from_ccd_snr(snr, countrate)
     <Quantity 5.19489883e-07 s>
 

--- a/docs/synphot/observation.rst
+++ b/docs/synphot/observation.rst
@@ -90,8 +90,29 @@ some binning. By default, it uses ``binset``, which should be defined such that
 one wavelength bin corresponds to one detector pixel::
 
     >>> area = 45238.93416  # HST, in cm^2
-    >>> obs.countrate(area)
+    >>> countrate = obs.countrate(area)
+    >>> countrate
     <Quantity 1.9249653e+10 ct / s>
+
+:func:`~synphot.observation.howell_snr` is a function which will compute the
+signal to noise ratio of an observation given its count rate and exposure
+time::
+
+    >>> from synphot.observation import howell_snr
+    >>> import astropy.units as u
+    >>> exptime = 1 * u.s
+    >>> howell_snr(countrate * exptime)
+    <Quantity 138743.11880657 ct(1/2)>
+
+Or, to determine the exposure time needed to reach a certain signal to noise
+ratio, use the :func:`~synphot.observation.exptime_from_howell_snr`
+function with the observation's count rate::
+
+    >>> from synphot.observation import exptime_from_howell_snr
+    >>> import numpy as np
+    >>> snr = 100 * np.sqrt(1 * u.ct)  # desired SNR of 100
+    >>> exptime_from_howell_snr(snr, countrate)
+    <Quantity 5.19489883e-07 s>
 
 An observation can be converted to a **regular source spectrum** containing
 only the wavelength set and sampled flux (binned by default) by using its

--- a/docs/synphot/observation.rst
+++ b/docs/synphot/observation.rst
@@ -94,24 +94,24 @@ one wavelength bin corresponds to one detector pixel::
     >>> countrate
     <Quantity 1.9249653e+10 ct / s>
 
-:func:`~synphot.observation.howell_snr` is a function which will compute the
+:func:`~synphot.observation.ccd_snr` is a function which will compute the
 signal to noise ratio of an observation given its count rate and exposure
 time::
 
-    >>> from synphot.observation import howell_snr
+    >>> from synphot.observation import ccd_snr
     >>> import astropy.units as u
     >>> exptime = 1 * u.s
-    >>> howell_snr(countrate * exptime)
+    >>> ccd_snr(countrate * exptime)
     <Quantity 138743.11880657 ct(1/2)>
 
 Or, to determine the exposure time needed to reach a certain signal to noise
-ratio, use the :func:`~synphot.observation.exptime_from_howell_snr`
+ratio, use the :func:`~synphot.observation.exptime_from_ccd_snr`
 function with the observation's count rate::
 
-    >>> from synphot.observation import exptime_from_howell_snr
+    >>> from synphot.observation import exptime_from_ccd_snr
     >>> import numpy as np
     >>> snr = 100 * np.sqrt(1 * u.ct)  # desired SNR of 100
-    >>> exptime_from_howell_snr(snr, countrate)
+    >>> exptime_from_ccd_snr(snr, countrate)
     <Quantity 5.19489883e-07 s>
 
 An observation can be converted to a **regular source spectrum** containing

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -726,7 +726,7 @@ def ccd_snr(counts,
         Total number of counts in an arbitrary exposure time with units of
         either astropy.units.ct, astropy.units.electron, or
         astropy.units.photon. Be aware that count units may refer to different
-        physical units for different instruments (e.g. one instrument may be
+        physical units for different instruments (e.g., one instrument may be
         "count"ing electrons, while another may be counting analog-to-digital
         units [ADU]). In the latter case, the user must first multiply their
         counts by the instrument gain to reflect the correct number of counts
@@ -782,7 +782,7 @@ def ccd_snr(counts,
         counts = counts.value * u.ct
     elif counts.unit != u.ct:
         raise u.UnitsError('counts must have units of either '
-                           'astropy.units.ct, astropy.units.electron '
+                           'astropy.units.ct, astropy.units.electron, '
                            'or astropy.units.photon')
 
     readnoise = _get_shotnoise(readnoise)
@@ -880,10 +880,10 @@ def exptime_from_ccd_snr(snr, countrate,
         to noise ratio.
     """
     if countrate.unit in (u.electron / u.s, u.photon / u.s):
-        countrate = countrate.value * u.ct / u.s
+        countrate = countrate.value * (u.ct / u.s)
     elif countrate.unit != u.ct / u.s:
         raise u.UnitsError('countrate must have units of (either '
-                           'astropy.units.ct, astropy.units.electron or '
+                           'astropy.units.ct, astropy.units.electron, or '
                            'astropy.units.photon) / astropy.units.s')
 
     # necessary for units to work:

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -918,7 +918,7 @@ def _get_shotnoise(detector_property):
     """
     # Ensure detector_property is in the correct units:
     detector_property = detector_property.to(u.ct / u.pixel)
-    return detector_property.value * np.sqrt(1 * u.ct / u.pixel)
+    return detector_property.value * np.sqrt(1 * (u.ct / u.pixel))
 
 
 def _t_with_small_errs(t, background_rate, darkcurrent_rate, gain_err,

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -22,7 +22,7 @@ from . import binning, exceptions, units, utils
 from .models import Empirical1D
 from .spectrum import BaseSourceSpectrum, SourceSpectrum, SpectralElement
 
-__all__ = ['Observation']
+__all__ = ['Observation', 'howell_snr', 'exptime_from_howell_snr']
 
 
 class Observation(BaseSourceSpectrum):
@@ -715,7 +715,7 @@ def howell_snr(counts,
                darkcurrent=0 * (u.electron / u.pixel),
                readnoise=0 * (u.electron / u.pixel),
                gain=1 * (u.electron / u.adu),
-               ad_err=ad_err_default):
+               ad_err=AD_ERR_DEFAULT):
     """
     A function to calculate the idealized theoretical signal to noise ratio
     (SNR) of an astronomical observation with a given number of counts. This
@@ -801,7 +801,7 @@ def exptime_from_howell_snr(snr, countrate,
                             darkcurrent_rate=0 * (u.electron / u.pixel / u.s),
                             readnoise=0 * (u.electron / u.pixel),
                             gain=1 * (u.electron / u.adu),
-                            ad_err=ad_err_default):
+                            ad_err=AD_ERR_DEFAULT):
     """
     Returns the exposure time needed in units of seconds to achieve
     the specified (idealized theoretical) signal to noise ratio

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -773,8 +773,8 @@ def howell_snr(counts,
     Returns
     -------
     snr : `~astropy.units.Quantity`
-        The signal to noise ratio of the given observation in units of
-        sqrt(counts).
+        The signal to noise ratio of the given observation in dimensionless
+        units.
     """
     readnoise = _get_shotnoise(readnoise)
     gain_err = _get_shotnoise(gain * ad_err)
@@ -783,11 +783,11 @@ def howell_snr(counts,
     detector_noise = (background + darkcurrent +
                       readnoise ** 2 + gain_err ** 2)
 
-    return counts / np.sqrt(counts + pixel_terms * detector_noise)
+    return (counts / np.sqrt(counts + pixel_terms * detector_noise) / 
+            np.sqrt(1 * u.ct))
 
 
-@u.quantity_input(snr=np.sqrt(1 * u.ct),
-                  countrate=u.ct / u.s,
+@u.quantity_input(countrate=u.ct / u.s,
                   npix=u.pixel,
                   n_background=u.pixel,
                   background_rate=u.ct / u.pixel / u.s,
@@ -810,9 +810,9 @@ def exptime_from_howell_snr(snr, countrate,
 
     Parameters
     ----------
-    snr : `~astropy.units.Quantity`
-        The signal to noise ratio of the given observation in units of
-        sqrt(counts).
+    snr : float, int, or `~astropy.units.Quantity`
+        The signal to noise ratio of the given observation in dimensionless
+        units.
     countrate : `~astropy.units.Quantity`
         The counts per second with units of astropy.units.ct/second. Be aware
         that the count unit may refer to different physical units for different
@@ -867,6 +867,8 @@ def exptime_from_howell_snr(snr, countrate,
         The exposure time needed (in seconds) to achieve the given signal
         to noise ratio.
     """
+    # necessary for units to work:
+    snr = snr * np.sqrt(1 * u.ct)
     readnoise = _get_shotnoise(readnoise)
     gain_err = _get_shotnoise(gain * ad_err)
 

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -700,21 +700,21 @@ class Observation(BaseSourceSpectrum):
 AD_ERR_DEFAULT = np.sqrt(0.289) * (u.adu / u.pixel)
 
 
-@u.quantity_input(counts=u.electron,
+@u.quantity_input(counts=u.ct,
                   npix=u.pixel,
                   n_background=u.pixel,
-                  background=u.electron / u.pixel,
-                  darkcurrent=u.electron / u.pixel,
-                  readnoise=u.electron / u.pixel,
-                  gain=u.electron / u.adu,
+                  background=u.ct / u.pixel,
+                  darkcurrent=u.ct / u.pixel,
+                  readnoise=u.ct / u.pixel,
+                  gain=u.ct / u.adu,
                   ad_err=u.adu / u.pixel)
 def howell_snr(counts,
                npix=1 * u.pixel,
                n_background=np.inf * u.pixel,
-               background=0 * (u.electron / u.pixel),
-               darkcurrent=0 * (u.electron / u.pixel),
-               readnoise=0 * (u.electron / u.pixel),
-               gain=1 * (u.electron / u.adu),
+               background=0 * (u.ct / u.pixel),
+               darkcurrent=0 * (u.ct / u.pixel),
+               readnoise=0 * (u.ct / u.pixel),
+               gain=1 * (u.ct / u.adu),
                ad_err=AD_ERR_DEFAULT):
     """
     A function to calculate the idealized theoretical signal to noise ratio
@@ -725,7 +725,10 @@ def howell_snr(counts,
     ----------
     counts : `~astropy.units.Quantity`
         Total number of counts in an arbitrary exposure time with units of
-        electrons.
+        astropy.units.ct. Be aware that these units may refer to different
+        physical units for different instruments (e.g. one instrument may be
+        "count"ing electrons, while another may be counting analog-to-digital
+        units [ADU]).
     npix : `~astropy.units.Quantity`, optional
         Number of pixels under consideration for the signal with units of
         pixels. Default is 1 * astropy.units.pixel.
@@ -736,18 +739,18 @@ def howell_snr(counts,
         estimation. This assumes that n_background will be >> npix.
     background : `~astropy.units.Quantity`, optional
         Total photons per pixel due to the background/sky with units of
-        electrons/pixel.
-        Default is 0 * astropy.units.electron / astropy.units.pixel.
+        counts/pixel.
+        Default is 0 * astropy.units.ct / astropy.units.pixel.
     darkcurrent : `~astropy.units.Quantity`, optional
-        Total electrons per pixel due to the dark current with units
-        of electrons/pixel.
-        Default is 0 * astropy.units.electron / astropy.units.pixel.
+        Total counts per pixel due to the dark current with units
+        of counts/pixel.
+        Default is 0 * astropy.units.ct / astropy.units.pixel.
     readnoise : `~astropy.units.Quantity`, optional
-        Electrons per pixel from the read noise with units of electrons/pixel.
-        Default is 0 * astropy.units.electron / astropy.units.pixel.
+        Counts per pixel from the read noise with units of counts/pixel.
+        Default is 0 * astropy.units.ct / astropy.units.pixel.
     gain : `~astropy.units.Quantity`, optional
-        Gain of the CCD with units of electrons/ADU. Default is
-        1 * astropy.units.electron / astropy.units.adu such that the
+        Gain of the CCD with units of counts/ADU. Default is
+        1 * astropy.units.ct / astropy.units.adu such that the
         contribution to the error due to the gain is assumed to be small.
     ad_err : `~astropy.units.Quantity`, optional
         An estimate of the 1 sigma error within the A/D converter with units of
@@ -771,7 +774,7 @@ def howell_snr(counts,
     -------
     sn : `~astropy.units.Quantity`
         The signal to noise ratio of the given observation in units of
-        sqrt(electrons).
+        sqrt(counts).
     """
     readnoise = _get_shotnoise(readnoise)
     gain_err = _get_shotnoise(gain * ad_err)
@@ -785,22 +788,22 @@ def howell_snr(counts,
     return sn
 
 
-@u.quantity_input(snr=np.sqrt(1 * u.electron),
-                  countrate=u.electron / u.s,
+@u.quantity_input(snr=np.sqrt(1 * u.ct),
+                  countrate=u.ct / u.s,
                   npix=u.pixel,
                   n_background=u.pixel,
-                  background_rate=u.electron / u.pixel / u.s,
-                  darkcurrent_rate=u.electron / u.pixel / u.s,
-                  readnoise=u.electron / u.pixel,
-                  gain=u.electron / u.adu,
+                  background_rate=u.ct / u.pixel / u.s,
+                  darkcurrent_rate=u.ct / u.pixel / u.s,
+                  readnoise=u.ct / u.pixel,
+                  gain=u.ct / u.adu,
                   ad_err=u.adu / u.pixel)
 def exptime_from_howell_snr(snr, countrate,
                             npix=1 * u.pixel,
                             n_background=np.inf * u.pixel,
-                            background_rate=0 * (u.electron / u.pixel / u.s),
-                            darkcurrent_rate=0 * (u.electron / u.pixel / u.s),
-                            readnoise=0 * (u.electron / u.pixel),
-                            gain=1 * (u.electron / u.adu),
+                            background_rate=0 * (u.ct / u.pixel / u.s),
+                            darkcurrent_rate=0 * (u.ct / u.pixel / u.s),
+                            readnoise=0 * (u.ct / u.pixel),
+                            gain=1 * (u.ct / u.adu),
                             ad_err=AD_ERR_DEFAULT):
     """
     Returns the exposure time needed in units of seconds to achieve
@@ -811,9 +814,12 @@ def exptime_from_howell_snr(snr, countrate,
     ----------
     snr : `~astropy.units.Quantity`
         The signal to noise ratio of the given observation in units of
-        sqrt(electrons).
+        sqrt(counts).
     countrate : `~astropy.units.Quantity`
-        The counts per second with units of electron/second.
+        The counts per second with units of astropy.units.ct/second. Be aware
+        that the count unit may refer to different physical units for different
+        instruments (e.g. one instrument may be "count"ing electrons, while
+        another may be counting analog-to-digital units [ADU]).
     npix : `~astropy.units.Quantity`, optional
         Number of pixels under consideration for the signal with units of
         pixels. Default is 1 * astropy.units.pixel.
@@ -824,20 +830,20 @@ def exptime_from_howell_snr(snr, countrate,
         estimation. This assumes that n_background will be >> npix.
     background_rate : `~astropy.units.Quantity`, optional
         Photons per pixel per second due to the backround/sky with units of
-        electrons/second/pixel.
-        Default is 0 * (astropy.units.electron /
+        counts/second/pixel.
+        Default is 0 * (astropy.units.ct /
         astropy.units.second / astropy.units.pixel)
     darkcurrent_rate : `~astropy.units.Quantity`, optional
-        Electrons per pixel per second due to the dark current with units
-        of electrons/second/pixel.
-        Default is 0 * (astropy.units.electron /
+        Counts per pixel per second due to the dark current with units
+        of counts/second/pixel.
+        Default is 0 * (astropy.units.ct /
         astropy.units.second / astropy.units.pixel)
     readnoise : `~astropy.units.Quantity`, optional
-        Electrons per pixel from the read noise with units of electrons/pixel.
-        Default is 0 * astropy.units.electron / astropy.units.pixel.
+        Counts per pixel from the read noise with units of counts/pixel.
+        Default is 0 * astropy.units.ct / astropy.units.pixel.
     gain : `~astropy.units.Quantity`, optional
-        Gain of the CCD with units of electrons/ADU. Default is
-        1 * astropy.units.electron / astropy.units.adu such that the
+        Gain of the CCD with units of counts/ADU. Default is
+        1 * astropy.units.ct / astropy.units.adu such that the
         contribution to the error due to the gain is assumed to be small.
     ad_err : `~astropy.units.Quantity`, optional
         An estimate of the 1 sigma error within the A/D converter with units of
@@ -892,8 +898,8 @@ def _get_shotnoise(detector_property):
     units. ``detector_property`` must be a Quantity.
     """
     # Ensure detector_property is in the correct units:
-    detector_property = detector_property.to(u.electron / u.pixel)
-    return detector_property.value * np.sqrt(1 * u.electron / u.pixel)
+    detector_property = detector_property.to(u.ct / u.pixel)
+    return detector_property.value * np.sqrt(1 * u.ct / u.pixel)
 
 
 def _t_with_small_errs(t, background_rate, darkcurrent_rate, gain_err,

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -724,10 +724,13 @@ def ccd_snr(counts,
     ----------
     counts : `~astropy.units.Quantity`
         Total number of counts in an arbitrary exposure time with units of
-        astropy.units.ct. Be aware that these units may refer to different
+        either astropy.units.ct, astropy.units.electron, or
+        astropy.units.photon. Be aware that count units may refer to different
         physical units for different instruments (e.g. one instrument may be
         "count"ing electrons, while another may be counting analog-to-digital
-        units [ADU]).
+        units [ADU]). In the latter case, the user must first multiply their
+        counts by the instrument gain to reflect the correct number of counts
+        for their instrument.
     npix : `~astropy.units.Quantity`, optional
         Number of pixels under consideration for the signal with units of
         pixels. Default is 1 * astropy.units.pixel.
@@ -819,10 +822,14 @@ def exptime_from_ccd_snr(snr, countrate,
         The signal to noise ratio of the given observation in dimensionless
         units.
     countrate : `~astropy.units.Quantity`
-        The counts per second with units of astropy.units.ct/second. Be aware
-        that the count unit may refer to different physical units for different
-        instruments (e.g. one instrument may be "count"ing electrons, while
-        another may be counting analog-to-digital units [ADU]).
+        The counts per second with units of (either astropy.units.ct,
+        astropy.units.electron or astropy.units.photon) / astropy.units.s.
+        Be aware that count units may refer to different physical units for
+        different instruments (e.g. one instrument may be "count"ing
+        electrons, while another may be counting analog-to-digital
+        units [ADU]). In the latter case, the user must first multiply their
+        counts by the instrument gain to reflect the correct number of counts
+        for their instrument.
     npix : `~astropy.units.Quantity`, optional
         Number of pixels under consideration for the signal with units of
         pixels. Default is 1 * astropy.units.pixel.

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -880,14 +880,14 @@ def exptime_from_howell_snr(snr, countrate,
 
     t = (-B + np.sqrt(B ** 2 - 4 * A * C)) / (2 * A)
 
-    if gain_err.value > 1 or not np.isfinite(n_background.value):
+    if gain_err.value > 1 or np.isfinite(n_background.value):
         from scipy.optimize import fsolve
         # solve t numerically
         t = fsolve(_t_with_small_errs, t, args=(background_rate,
                                                 darkcurrent_rate,
                                                 gain_err, readnoise, countrate,
                                                 npix, n_background))
-        t = t * u.s
+        t = float(t) * u.s
 
     return t
 

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -713,7 +713,7 @@ def ccd_snr(counts,
             background=0 * (u.ct / u.pixel),
             darkcurrent=0 * (u.ct / u.pixel),
             readnoise=0 * (u.ct / u.pixel),
-            gain=1 * (u.ct / u.adu),
+            gain=0 * (u.ct / u.adu),
             ad_err=AD_ERR_DEFAULT):
     """
     A function to calculate the idealized theoretical signal to noise ratio
@@ -752,8 +752,8 @@ def ccd_snr(counts,
         Default is 0 * astropy.units.ct / astropy.units.pixel.
     gain : `~astropy.units.Quantity`, optional
         Gain of the CCD with units of counts/ADU. Default is
-        1 * astropy.units.ct / astropy.units.adu such that the
-        contribution to the error due to the gain is assumed to be small.
+        0 * astropy.units.ct / astropy.units.adu such that the
+        contribution to the error due to the gain is assumed to be negligable.
     ad_err : `~astropy.units.Quantity`, optional
         An estimate of the 1 sigma error within the A/D converter with units of
         adu/pixel. Default is set to

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -15,7 +15,6 @@ from scipy.optimize import fsolve
 # ASTROPY
 from astropy import log
 from astropy import units as u
-from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.exceptions import (AstropyUserWarning,
                                       AstropyDeprecationWarning)
 
@@ -907,7 +906,7 @@ def _t_with_small_errs(t, background_rate, darkcurrent_rate, gain_err,
 
     detector_noise = (background_rate * t + darkcurrent_rate * t +
                       gain_err ** 2 + readnoise ** 2)
-    radicand = countrate * t + (npix * (1 + npix/n_background) *
+    radicand = countrate * t + (npix * (1 + npix / n_background) *
                                 detector_noise)
 
     return countrate * t / np.sqrt(radicand)

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -783,7 +783,7 @@ def howell_snr(counts,
     detector_noise = (background + darkcurrent +
                       readnoise ** 2 + gain_err ** 2)
 
-    return (counts / np.sqrt(counts + pixel_terms * detector_noise) / 
+    return (counts / np.sqrt(counts + pixel_terms * detector_noise) /
             np.sqrt(1 * u.ct))
 
 

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -772,7 +772,7 @@ def howell_snr(counts,
 
     Returns
     -------
-    sn : `~astropy.units.Quantity`
+    snr : `~astropy.units.Quantity`
         The signal to noise ratio of the given observation in units of
         sqrt(counts).
     """
@@ -783,9 +783,7 @@ def howell_snr(counts,
     detector_noise = (background + darkcurrent +
                       readnoise ** 2 + gain_err ** 2)
 
-    sn = counts / np.sqrt(counts + pixel_terms * detector_noise)
-
-    return sn
+    return counts / np.sqrt(counts + pixel_terms * detector_noise)
 
 
 @u.quantity_input(snr=np.sqrt(1 * u.ct),

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -10,10 +10,12 @@ import warnings
 
 # THIRD-PARTY
 import numpy as np
+from scipy.optimize import fsolve
 
 # ASTROPY
 from astropy import log
 from astropy import units as u
+from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.exceptions import (AstropyUserWarning,
                                       AstropyDeprecationWarning)
 
@@ -694,3 +696,218 @@ class Observation(BaseSourceSpectrum):
         header = {'observation': str(self), 'binned': binned}
         return SourceSpectrum(Empirical1D, points=w, lookup_table=y,
                               meta={'header': header})
+
+
+ad_err_default = np.sqrt(0.289) * u.adu / u.pixel
+
+
+@u.quantity_input(counts=u.electron,
+                  npix=u.pixel,
+                  n_background=u.pixel,
+                  background=u.electron / u.pixel,
+                  darkcurrent=u.electron / u.pixel,
+                  readnoise=u.electron / u.pixel,
+                  gain=u.electron / u.adu,
+                  ad_err=u.adu / u.pixel)
+def howell_snr(counts,
+               npix=1 * u.pixel,
+               n_background=np.inf * u.pixel,
+               background=0 * u.electron / u.pixel,
+               darkcurrent=0 * u.electron / u.pixel,
+               readnoise=0 * u.electron / u.pixel,
+               gain=1 * u.electron / u.adu,
+               ad_err=ad_err_default):
+    """
+    A function to calculate the idealized theoretical signal to noise ratio
+    (SNR) of an astronomical observation with a given number of counts. This
+    expression is taken from pg 55 of [1]_).
+
+    Parameters
+    ----------
+    counts : `~astropy.units.Quantity`
+        Total number of counts in an arbitrary exposure time with units of
+        electrons.
+    npix : `~astropy.units.Quantity`, optional
+        Number of pixels under consideration for the signal with units of
+        pixels. Default is 1 * astropy.units.pixel.
+    n_background : `~astropy.units.Quantity`, optional
+        Number of pixels used in the background estimation with units of
+        pixels. Default is set to np.inf * astropy.units.pixel
+        such that there is no contribution of error due to background
+        estimation. This assumes that n_background will be >> npix.
+    background : `~astropy.units.Quantity`, optional
+        Total photons per pixel due to the background/sky with units of
+        electrons/pixel.
+        Default is 0 * astropy.units.electron / astropy.units.pixel.
+    darkcurrent : `~astropy.units.Quantity`, optional
+        Total electrons per pixel due to the dark current with units
+        of electrons/pixel.
+        Default is 0 * astropy.units.electron / astropy.units.pixel.
+    readnoise : `~astropy.units.Quantity`, optional
+        Electrons per pixel from the read noise with units of electrons/pixel.
+        Default is 0 * astropy.units.electron / astropy.units.pixel.
+    gain : `~astropy.units.Quantity`, optional
+        Gain of the CCD with units of electrons/ADU. Default is
+        1 * astropy.units.electron / astropy.units.adu such that the
+        contribution to the error due to the gain is assumed to be small.
+    ad_err : `~astropy.units.Quantity`, optional
+        An estimate of the 1 sigma error within the A/D converter with units of
+        adu/pixel. Default is set to
+        sqrt(0.289) * astropy.units.adu / astropy.units.pixel, where
+        sqrt(0.289) comes from the assumption that "for a charge level that is
+        half way between two output ADU steps, there is an equal chance that it
+        will be assigned to the lower or to the higher ADU value when converted
+        to a digital number" (text from footnote on page 56 of [1]_, see also
+        [2]_).
+
+    References
+    ----------
+    .. [1] Howell, S. B. 2000, *Handbook of CCD Astronomy* (Cambridge, UK:
+        Cambridge University Press)
+    .. [2] Merline, W. & Howell, S. B. *A Realistic Model for Point-sources
+        Imaged on Array Detectors: The Model and Initial Results*. ExA, 6:163
+        (1995)
+
+    Returns
+    -------
+    sn : `~astropy.units.Quantity`
+        The signal to noise ratio of the given observation in units of
+        sqrt(electrons).
+    """
+    readnoise = _get_shotnoise(readnoise)
+    gain_err = _get_shotnoise(gain * ad_err)
+
+    pixel_terms = npix * (1 + npix / n_background)
+    detector_noise = (background + darkcurrent +
+                      readnoise ** 2 + gain_err ** 2)
+
+    sn = counts / np.sqrt(counts + pixel_terms * detector_noise)
+
+    return sn
+
+
+@u.quantity_input(snr=np.sqrt(1 * u.electron),
+                  countrate=u.electron / u.s,
+                  npix=u.pixel,
+                  n_background=u.pixel,
+                  background_rate=u.electron / u.pixel / u.s,
+                  darkcurrent_rate=u.electron / u.pixel / u.s,
+                  readnoise=u.electron / u.pixel,
+                  gain=u.electron / u.adu,
+                  ad_err=u.adu / u.pixel)
+def exptime_from_howell_snr(snr, countrate,
+                            npix=1 * u.pixel,
+                            n_background=np.inf * u.pixel,
+                            background_rate=0 * u.electron / u.pixel / u.s,
+                            darkcurrent_rate=0 * u.electron / u.pixel / u.s,
+                            readnoise=0 * u.electron / u.pixel,
+                            gain=1 * u.electron / u.adu,
+                            ad_err=ad_err_default):
+    """
+    Returns the exposure time needed in units of seconds to achieve
+    the specified (idealized theoretical) signal to noise ratio
+    (from pg 57-58 of [1]_).
+
+    Parameters
+    ----------
+    snr : `~astropy.units.Quantity`
+        The signal to noise ratio of the given observation in units of
+        sqrt(electrons).
+    countrate : `~astropy.units.Quantity`
+        The counts per second with units of electron/second.
+    npix : `~astropy.units.Quantity`, optional
+        Number of pixels under consideration for the signal with units of
+        pixels. Default is 1 * astropy.units.pixel.
+    n_background : `~astropy.units.Quantity`, optional
+        Number of pixels used in the background estimation with units of
+        pixels. Default is set to np.inf * astropy.units.pixel
+        such that there is no contribution of error due to background
+        estimation. This assumes that n_background will be >> npix.
+    background_rate : `~astropy.units.Quantity`, optional
+        Photons per pixel per second due to the backround/sky with units of
+        electrons/second/pixel.
+        Default is 0 * (astropy.units.electron /
+                        astropy.units.second / astropy.units.pixel)
+    darkcurrent_rate : `~astropy.units.Quantity`, optional
+        Electrons per pixel per second due to the dark current with units
+        of electrons/second/pixel.
+        Default is 0 * (astropy.units.electron /
+                        astropy.units.second / astropy.units.pixel)
+    readnoise : `~astropy.units.Quantity`, optional
+        Electrons per pixel from the read noise with units of electrons/pixel.
+        Default is 0 * astropy.units.electron / astropy.units.pixel.
+    gain : `~astropy.units.Quantity`, optional
+        Gain of the CCD with units of electrons/ADU. Default is
+        1 * astropy.units.electron / astropy.units.adu such that the
+        contribution to the error due to the gain is assumed to be small.
+    ad_err : `~astropy.units.Quantity`, optional
+        An estimate of the 1 sigma error within the A/D converter with units of
+        adu/pixel. Default is set to
+        sqrt(0.289) * astropy.units.adu / astropy.units.pixel, where
+        sqrt(0.289) comes from the assumption that "for a charge level that is
+        half way between two output ADU steps, there is an equal chance that it
+        will be assigned to the lower or to the higher ADU value when converted
+        to a digital number" (text from footnote on page 56 of [1]_, see also
+        [2]_).
+
+    References
+    ----------
+    .. [1] Howell, S. B. 2000, *Handbook of CCD Astronomy* (Cambridge, UK:
+        Cambridge University Press)
+    .. [2] Merline, W. & Howell, S. B. *A Realistic Model for Point-sources
+        Imaged on Array Detectors: The Model and Initial Results*. ExA, 6:163
+        (1995)
+
+    Returns
+    -------
+    t : `~astropy.units.Quantity`
+        The exposure time needed (in seconds) to achieve the given signal
+        to noise ratio.
+    """
+    readnoise = _get_shotnoise(readnoise)
+    gain_err = _get_shotnoise(gain * ad_err)
+
+    # solve t with the quadratic equation (pg. 57 of Howell 2000)
+    A = countrate ** 2
+    B = (-1) * snr ** 2 * (countrate + npix * (background_rate +
+                                               darkcurrent_rate))
+    C = (-1) * snr ** 2 * npix * readnoise ** 2
+
+    t = (-B + np.sqrt(B ** 2 - 4 * A * C)) / (2 * A)
+
+    if gain_err.value > 1 or not np.isfinite(n_background.value):
+        # solve t numerically
+        t = fsolve(_t_with_small_errs, t, args=(background_rate,
+                                                darkcurrent_rate,
+                                                gain_err, readnoise, countrate,
+                                                npix, n_background))
+        t = t * u.s
+
+    return t
+
+
+def _get_shotnoise(detector_property):
+    """
+    Returns the shot noise (i.e. non-Poissonion noise) in the correct
+    units.
+    """
+    # Ensure detector_property is in the correct units:
+    detector_property = detector_property.to(u.electron / u.pixel)
+    return detector_property.value * np.sqrt(1 * u.electron / u.pixel)
+
+
+def _t_with_small_errs(t, background_rate, darkcurrent_rate, gain_err,
+                       readnoise, countrate, npix, n_background):
+    """
+    Returns the full expression for the exposure time including the
+    contribution to the noise from the background and the gain.
+    """
+    if not hasattr(t, 'unit'):
+        t = t * u.s
+
+    detector_noise = (background_rate * t + darkcurrent_rate * t +
+                      gain_err ** 2 + readnoise ** 2)
+    radicand = countrate * t + (npix * (1 + npix/n_background) *
+                                detector_noise)
+
+    return countrate * t / np.sqrt(radicand)

--- a/synphot/tests/test_observation.py
+++ b/synphot/tests/test_observation.py
@@ -466,11 +466,10 @@ def test_howell_snr_calc():
                         gain=gain, n_background=n_background)
 
     # the value of the answer given in the text
-    ans_unit = np.sqrt(1 * u.ct)
-    answer = 342 * ans_unit
+    answer = 342
 
     # allow error to be +/- 1 for this test
-    assert_quantity_allclose(result, answer, atol=1 * ans_unit)
+    assert_quantity_allclose(result, answer, atol=1)
 
 
 def test_snr_bright_object():
@@ -480,7 +479,7 @@ def test_snr_bright_object():
     """
     counts = 25e5 * u.ct
     result = howell_snr(counts)
-    answer = np.sqrt(counts)
+    answer = np.sqrt(counts.value)
 
     assert_quantity_allclose(result, answer)
 
@@ -498,7 +497,7 @@ def test_t_exp_numeric():
         Cambridge University Press)
     """
     t = 300 * u.s
-    snr = 342 * np.sqrt(1 * u.ct)
+    snr = 342
     gain = 5 * (u.ct / u.adu)
     countrate = 24013 * u.adu * gain / t
     npix = 1 * u.pixel
@@ -521,7 +520,7 @@ def test_t_exp_analytic():
     A test to check that the analytic method in
     observation.exptime_from_howell_snr is done correctly.
     """
-    snr_set = 50 * np.sqrt(1 * u.ct)
+    snr_set = 50
     countrate = 1000 * (u.ct / u.s)
     npix = 1 * u.pixel
     background_rate = 100 * (u.ct / u.pixel / u.s)
@@ -541,7 +540,7 @@ def test_t_exp_analytic():
                           readnoise=readnoise)
 
     assert_quantity_allclose(snr_calc, snr_set,
-                             atol=0.5 * np.sqrt(1 * u.ct))
+                             atol=0.5 * u.Unit(""))
 
 
 def test_snr_with_countrate():
@@ -555,4 +554,4 @@ def test_snr_with_countrate():
     counts = obs.countrate(1 * u.m ** 2) * 1 * u.s
     snr = howell_snr(counts)
 
-    assert snr.unit == u.Unit("ct(1/2)")
+    assert snr.unit == u.Unit("")

--- a/synphot/tests/test_observation.py
+++ b/synphot/tests/test_observation.py
@@ -548,19 +548,23 @@ def test_snr_with_countrate():
     A test to make sure `ccd_snr` works with the units that
     `countrate` returns.
     """
-    source_spec = SourceSpectrum(BlackBodyNorm1D)
+    area = 1 * u.m ** 2
     bp = SpectralElement(Const1D)
+    source_spec = SourceSpectrum(BlackBodyNorm1D)
+    source_spec = source_spec.normalize(
+        1 * u.ct, bp, force='extrap', wavelengths=source_spec.waveset, area=area)
     obs = Observation(source_spec, bp, force='extrap')
-    counts = obs.countrate(1 * u.m ** 2) * 1 * u.s
+    counts = obs.countrate(area) * u.s
     snr = ccd_snr(counts)
 
     assert snr.unit == u.Unit("")
+    np.testing.assert_allclose(snr.value, ???)
 
 
 @raises(u.UnitsError)
 def test_counts_units():
     """
-    A test to make sure `ccd_snr` raises a UnitError if the user
+    A test to make sure ``ccd_snr`` raises a UnitError if the user
     gives an incompatible unit for counts.
     """
     return ccd_snr(1 * u.m)
@@ -569,7 +573,7 @@ def test_counts_units():
 @raises(u.UnitsError)
 def test_countrate_units():
     """
-    A test to make sure `exptime_from_ccd_snr` raises a UnitError
+    A test to make sure ``exptime_from_ccd_snr`` raises a UnitError
     if the user gives an incompatible countrate unit.
     """
     return exptime_from_ccd_snr(10, 1 * u.m)

--- a/synphot/tests/test_observation.py
+++ b/synphot/tests/test_observation.py
@@ -546,6 +546,13 @@ def test_t_exp_analytic():
 
 def test_snr_with_countrate():
     """
-    A test to make sure `howell_snr` works with what `countrate` returns.
+    A test to make sure `howell_snr` works with the units that
+    `countrate` returns.
     """
-    
+    source_spec = SourceSpectrum(BlackBodyNorm1D)
+    bp = SpectralElement(Const1D)
+    obs = Observation(source_spec, bp, force='extrap')
+    counts = obs.countrate(1 * u.m ** 2) * 1 * u.s
+    snr = howell_snr(counts)
+
+    assert snr.unit == u.Unit("ct(1/2)")

--- a/synphot/tests/test_observation.py
+++ b/synphot/tests/test_observation.py
@@ -22,9 +22,7 @@ from .test_units import _area
 from .. import exceptions, units
 from ..models import (BlackBodyNorm1D, Box1D, ConstFlux1D, Empirical1D,
                       GaussianFlux1D)
-from ..observation import Observation
-from ..observation import howell_snr
-from ..observation import exptime_from_howell_snr
+from ..observation import Observation, howell_snr, exptime_from_howell_snr
 from ..spectrum import SourceSpectrum, SpectralElement
 
 try:
@@ -455,10 +453,10 @@ def test_howell_snr_calc():
         Cambridge University Press)
     """
     t = 300 * u.s
-    readnoise = 5 * u.electron / u.pixel
-    darkcurrent = 22 * t * u.electron / u.pixel / u.hr
-    gain = 5 * u.electron / u.adu
-    background = 620 * u.adu / u.pixel * gain
+    readnoise = 5 * (u.electron / u.pixel)
+    darkcurrent = 22 * t * (u.electron / u.pixel / u.hr)
+    gain = 5 * (u.electron / u.adu)
+    background = 620 * (u.adu / u.pixel * gain)
     n_background = 200 * u.pixel
     npix = 1 * u.pixel
     counts = 24013 * u.adu * gain
@@ -468,10 +466,11 @@ def test_howell_snr_calc():
                         gain=gain, n_background=n_background)
 
     # the value of the answer given in the text
-    answer = 342 * np.sqrt(1 * u.electron)
+    ans_unit = np.sqrt(1 * u.electron)
+    answer = 342 * ans_unit
 
     # allow error to be +/- 1 for this test
-    assert_quantity_allclose(result, answer, atol=1 * np.sqrt(1 * u.electron))
+    assert_quantity_allclose(result, answer, atol=1 * ans_unit)
 
 
 def test_snr_bright_object():
@@ -500,13 +499,13 @@ def test_t_exp_numeric():
     """
     t = 300 * u.s
     snr = 342 * np.sqrt(1 * u.electron)
-    gain = 5 * u.electron / u.adu
+    gain = 5 * (u.electron / u.adu)
     countrate = 24013 * u.adu * gain / t
     npix = 1 * u.pixel
     n_background = 200 * u.pixel
-    background_rate = 620 * u.adu / u.pixel * gain / t
-    darkcurrent_rate = 22 * u.electron / u.pixel / u.hr
-    readnoise = 5 * u.electron / u.pixel
+    background_rate = 620 * (u.adu / u.pixel) * gain / t
+    darkcurrent_rate = 22 * (u.electron / u.pixel / u.hr)
+    readnoise = 5 * (u.electron / u.pixel)
 
     result = exptime_from_howell_snr(snr, countrate, npix=npix,
                                      n_background=n_background,
@@ -523,11 +522,11 @@ def test_t_exp_analytic():
     observation.exptime_from_howell_snr is done correctly.
     """
     snr_set = 50 * np.sqrt(1 * u.electron)
-    countrate = 1000 * u.electron / u.s
+    countrate = 1000 * (u.electron / u.s)
     npix = 1 * u.pixel
-    background_rate = 100 * u.electron / u.pixel / u.s
-    darkcurrent_rate = 5 * u.electron / u.pixel / u.s
-    readnoise = 1 * u.electron / u.pixel
+    background_rate = 100 * (u.electron / u.pixel / u.s)
+    darkcurrent_rate = 5 * (u.electron / u.pixel / u.s)
+    readnoise = 1 * (u.electron / u.pixel)
 
     t = exptime_from_howell_snr(snr_set, countrate, npix=npix,
                                 background_rate=background_rate,

--- a/synphot/tests/test_observation.py
+++ b/synphot/tests/test_observation.py
@@ -453,9 +453,9 @@ def test_howell_snr_calc():
         Cambridge University Press)
     """
     t = 300 * u.s
-    readnoise = 5 * (u.electron / u.pixel)
-    darkcurrent = 22 * t * (u.electron / u.pixel / u.hr)
-    gain = 5 * (u.electron / u.adu)
+    readnoise = 5 * (u.ct / u.pixel)
+    darkcurrent = 22 * t * (u.ct / u.pixel / u.hr)
+    gain = 5 * (u.ct / u.adu)
     background = 620 * (u.adu / u.pixel * gain)
     n_background = 200 * u.pixel
     npix = 1 * u.pixel
@@ -466,7 +466,7 @@ def test_howell_snr_calc():
                         gain=gain, n_background=n_background)
 
     # the value of the answer given in the text
-    ans_unit = np.sqrt(1 * u.electron)
+    ans_unit = np.sqrt(1 * u.ct)
     answer = 342 * ans_unit
 
     # allow error to be +/- 1 for this test
@@ -478,7 +478,7 @@ def test_snr_bright_object():
     Test that observation.howell_snr returns sqrt(counts), the expected value
     for a bright target.
     """
-    counts = 25e5 * u.electron
+    counts = 25e5 * u.ct
     result = howell_snr(counts)
     answer = np.sqrt(counts)
 
@@ -498,14 +498,14 @@ def test_t_exp_numeric():
         Cambridge University Press)
     """
     t = 300 * u.s
-    snr = 342 * np.sqrt(1 * u.electron)
-    gain = 5 * (u.electron / u.adu)
+    snr = 342 * np.sqrt(1 * u.ct)
+    gain = 5 * (u.ct / u.adu)
     countrate = 24013 * u.adu * gain / t
     npix = 1 * u.pixel
     n_background = 200 * u.pixel
     background_rate = 620 * (u.adu / u.pixel) * gain / t
-    darkcurrent_rate = 22 * (u.electron / u.pixel / u.hr)
-    readnoise = 5 * (u.electron / u.pixel)
+    darkcurrent_rate = 22 * (u.ct / u.pixel / u.hr)
+    readnoise = 5 * (u.ct / u.pixel)
 
     result = exptime_from_howell_snr(snr, countrate, npix=npix,
                                      n_background=n_background,
@@ -521,12 +521,12 @@ def test_t_exp_analytic():
     A test to check that the analytic method in
     observation.exptime_from_howell_snr is done correctly.
     """
-    snr_set = 50 * np.sqrt(1 * u.electron)
-    countrate = 1000 * (u.electron / u.s)
+    snr_set = 50 * np.sqrt(1 * u.ct)
+    countrate = 1000 * (u.ct / u.s)
     npix = 1 * u.pixel
-    background_rate = 100 * (u.electron / u.pixel / u.s)
-    darkcurrent_rate = 5 * (u.electron / u.pixel / u.s)
-    readnoise = 1 * (u.electron / u.pixel)
+    background_rate = 100 * (u.ct / u.pixel / u.s)
+    darkcurrent_rate = 5 * (u.ct / u.pixel / u.s)
+    readnoise = 1 * (u.ct / u.pixel)
 
     t = exptime_from_howell_snr(snr_set, countrate, npix=npix,
                                 background_rate=background_rate,
@@ -541,4 +541,11 @@ def test_t_exp_analytic():
                           readnoise=readnoise)
 
     assert_quantity_allclose(snr_calc, snr_set,
-                             atol=0.5 * np.sqrt(1 * u.electron))
+                             atol=0.5 * np.sqrt(1 * u.ct))
+
+
+def test_snr_with_countrate():
+    """
+    A test to make sure `howell_snr` works with what `countrate` returns.
+    """
+    

--- a/synphot/tests/test_observation.py
+++ b/synphot/tests/test_observation.py
@@ -551,14 +551,15 @@ def test_snr_with_countrate():
     area = 1 * u.m ** 2
     bp = SpectralElement(Const1D)
     source_spec = SourceSpectrum(BlackBodyNorm1D)
-    source_spec = source_spec.normalize(
-        1 * u.ct, bp, force='extrap', wavelengths=source_spec.waveset, area=area)
+    source_spec = source_spec.normalize(1 * u.ct, bp,
+                                        force='extrap',
+                                        wavelengths=source_spec.waveset,
+                                        area=area)
     obs = Observation(source_spec, bp, force='extrap')
     counts = obs.countrate(area) * u.s
     snr = ccd_snr(counts)
 
-    assert snr.unit == u.Unit("")
-    np.testing.assert_allclose(snr.value, ???)
+    assert_quantity_allclose(snr, 1 * u.Unit(""), rtol=1e-3)
 
 
 @raises(u.UnitsError)


### PR DESCRIPTION
I have added two functions to `observation.py`:

- `howell_snr()` which returns the idealized theoretical signal to noise ratio from a given number of counts. The expression is taken from pg 55 of "Handbook of CCD Astronomy", Steve B. Howell, 2000. 
- `exptime_from_howell_snr()` which returns the exposure time needed in units of seconds to achieve the specified (idealized theoretical) signal to noise ratio (from pg 57-58 of Howell 2000).

Some tests for these functions have also been added to `tests/test_observation.py`

