### PR TITLE
WIP - A higher order function for wrapping synphot functionality

### DIFF
--- a/synphot/experimental/exposure.py
+++ b/synphot/experimental/exposure.py
@@ -1,0 +1,269 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""This module is a wrapper for synphot's most commonly used functions.
+
+"""
+
+# THIRD-PARTY
+import numpy as np
+
+# ASTROPY
+from astropy import units as u
+from astropy.modeling.models import Const1D
+
+# LOCAL
+from synphot.models import Empirical1D
+from synphot.spectrum import SpectralElement
+from .observation import Observation, ccd_snr, exptime_from_ccd_snr
+from synphot.experimental.skymodel import atmospheric_transmittance
+from synphot import exceptions
+
+__all__ = ['Exposure']
+
+
+AD_ERR_DEFAULT = np.sqrt(0.289) * (u.adu / u.pixel)
+
+
+class Exposure(object):
+    """
+    Parameters
+    ----------
+    source_spec : `~synphot.spectrum.SourceSpectrum`
+        The spectrum of the target object scaled by distance (i.e. the
+        target spectrum just before interacting with the instrument).
+    diameter : `~astropy.units.quantity.Quantity`
+        Diameter of the telescope aperture.
+    bandpass : str, list with dimension 2 x n containing
+        `~astropy.units.quantity.Quantity` values, or
+        `~synphot.spectrum.SpectralElement`
+        The bandpass(es) of this observation. Can either be specified by a
+        string or a list with dimensions 2 x n, where one row is the
+        list of wavelengths associated with the bandpass, and the other
+        row contains the fractional values of the bandpass.
+        Default is a constant model with amplitude = 1, i.e. as if a
+        bandpass with perfect throughput were in effect.
+    quantum_efficiency : bool or list with dimension 2 x n containing
+        `~astropy.units.quantity.Quantity` values
+        A model for the quantum efficiency of the instrument's CCD.
+        Default is False. If set to True, quantum_efficiency assumes
+        a generic silicon CCD response function.
+    atmospheric_transmission : bool or list with dimension 2 x n containing
+        `~astropy.units.quantity.Quantity` values
+        A model for the atmopsheric transmission. Default is False.
+        If set to True, atmospheric_transmission queries from SkyCalc
+        with default parameters. For more information on SkyCalc, see:
+        (http://www.eso.org/observing/etc/bin/gen/form?INS.MODE=
+        swspectr+INS.NAME=SKYCALC)
+        For more information on the default parameters, see:
+        (https://www.eso.org/observing/etc/doc/skycalc/helpskycalccli.
+        html#skycalc-input-parameters)
+    force : {None, ‘none’, ‘extrap’, ‘taper’}
+        Force the creation of an observation even when source spectrum
+        and bandpass do not fully overlap:
+
+            * `None` or 'none' - Source must encompass bandpass (default)
+            * 'extrap' - Extrapolate source spectrum (this changes the
+              underlying model of ``spec`` to always extrapolate,
+              if applicable)
+            * 'taper' - Taper source spectrum to zero
+    """
+    @u.quantity_input(diameter=u.m, exptime=u.s)
+    def __init__(self, source_spec, diameter, exptime,
+                 bandpass=SpectralElement(Const1D, amplitude=1),
+                 quantum_efficiency=False, atmospheric_transmission=False,
+                 force=None):
+        self.source_spec = source_spec
+        self.diameter = diameter
+        self.exptime = exptime
+        self._bandpass = bandpass
+        self._qe = quantum_efficiency
+        self._atmo = atmospheric_transmission
+
+        # turn spectrum elements into synphot objects
+        self._set_bandpass()
+
+        if type(self._qe) == list:
+            self._custom_qe()
+        elif self._qe is True:
+            self._generic_ccd()
+
+        if type(self._atmo) == list:
+            self._custom_atmosphere()
+        elif self._atmo is True:
+            self.atmospheric_transmission = atmospheric_transmittance()
+
+        self.observation = Observation(self.source_spec, self.throughput,
+                                       force=force)
+
+    @property
+    def aperture_area(self):
+        """ Area of the telescope aperture. """
+        return np.pi * (self.diameter / 2) ** 2
+
+    @property
+    def countrate(self):
+        """ Countrate of the observation in ct / s."""
+        return self.observation.countrate(area=self.aperture_area)
+
+    def _set_lists(self, _list, _list_str):
+        """
+        Turns user-provided models into SpectralElements.
+        Written such that the order in which the waveset and corresponding
+        values are given in the list does not matter.
+        """
+        if len(_list) != 2:
+            raise exceptions.BandpassError(_list_str + " should be "
+                                           "a list with 2 x n "
+                                           "dimensions.")
+        try:
+            __list = _call_SpecElement_4list(_list[0], _list[1])
+        except u.UnitsError:
+            try:
+                __list = _call_SpecElement_4list(_list[1], _list[0])
+            except u.UnitsError:
+                print("rows of " + _list_str + " list must be of type "
+                      "astropy.units.quantity.Quantity")
+        return __list
+
+    def _set_bandpass(self):
+        """
+        Sets the SpectralElement for the bandpass, which can be one of the
+        given synphot bandpasses, a custom user-provided model, or one already
+        set as a SpectralElement.
+        """
+        if type(self._bandpass) == list:
+            self.bandpass = self._set_lists(self._bandpass, 'bandpass')
+
+        elif type(self._bandpass) == str:
+            self.bandpass = SpectralElement.from_filter(self._bandpass)
+
+        elif type(self._bandpass) == SpectralElement:
+            self.bandpass = self._bandpass
+
+        else:
+            raise exceptions.BandpassError("bandpass must be of type str, "
+                                           "`~synphot.spectrum."
+                                           "SpectralElement`, or list of "
+                                           "shape(2, n) containing `~astropy"
+                                           ".units.quantity.Quantity` values"
+                                           )
+
+        self.throughput = self.bandpass
+
+    def _custom_qe(self):
+        """
+        Sets the SpectralElement for a given quantum efficiency and convolves
+        it with the total throughput.
+        """
+        self.quantum_efficiency = self._set_lists(self._qe,
+                                                  'quantum_efficiency')
+        self.throughput *= self.quantum_efficiency
+
+    def _generic_ccd(self):
+        """
+        Sets the SpectralElement for a generic throughput function of
+        a silicon detector and convolves it with the total throughput.
+        """
+        wl = [100., 309.45600215, 319.53901519, 329.99173871,
+              339.70504127, 349.78805431, 379.53294279, 390.00376402,
+              399.57293121, 409.3114413, 419.5961146, 429.14136695,
+              439.52687038, 449.9795939, 459.69289647, 469.60785929,
+              479.85892255, 489.5638226, 499.59835962, 509.99161922,
+              519.5607864, 529.30446727, 539.85285015, 549.59976275,
+              559.51472558, 569.94676599, 579.68075166, 589.59571448,
+              599.9631202, 609.56008031, 619.65269622, 630.09581687,
+              639.67467926, 649.50561697, 659.84070534, 669.7685951,
+              679.50258077, 689.9637068, 699.78494931, 709.53555533,
+              719.83463294, 729.72858948, 739.88431656, 749.9673296,
+              759.66253445, 769.59042422, 780.37854306, 789.59647942,
+              799.60677842, 810.07759966, 819.65646205, 829.52341053,
+              839.82248813, 849.68943661, 859.77244965, 870.07152726,
+              879.71760973, 889.81096433, 899.94245339, 909.73137855,
+              919.69435573, 930.06545485, 939.64431724, 949.72733028,
+              959.95862293, 969.6772918, 979.76030484, 990.05938245,
+              1100.]
+        response = [0., 70.30747425, 73.11442327, 75.26541144, 76.58538173,
+                    74.70200949, 77.10351031, 81.79762371, 84.528972,
+                    87.18136276, 89.0405892, 91.16038906, 92.49142617,
+                    93.66048522, 94.87582372, 95.64295585, 96.56602958,
+                    97.20551595, 98.01709918, 98.32588679, 98.26189462,
+                    98.79719419, 99.10133838, 99.09379281, 99.35788748,
+                    99.30100555, 99.14661175, 98.81209184, 98.74843825,
+                    98.30855134, 98.04495971, 97.98459522, 97.24513015,
+                    96.85779131, 96.40002722, 96.03435769, 95.87183789,
+                    95.09275863, 94.89671913, 94.49854563, 94.12126754,
+                    93.52139537, 92.57268607, 91.77633908, 90.30410094,
+                    88.68846298, 86.74856762, 84.85909033, 82.85400237,
+                    80.76562301, 78.18504085, 75.90628116, 72.63150731,
+                    68.93418199, 65.34249453, 61.79608045, 58.13799205,
+                    54.49429826, 49.87975185, 45.18326838, 41.57397462,
+                    36.82027063, 32.80603172, 28.7917928, 25.09446748,
+                    21.39714216, 18.4392819, 14.89286782, 0.]
+
+        self.quantum_efficiency = self._set_lists([wl, response],
+                                                  'quantum_efficiency')
+        self.throughput *= self.quantum_efficiency
+
+    def _custom_atmosphere(self):
+        """
+        Sets the SpectralElement for a user-provided atmospheric
+        transmission function and convolves it with the total throughput.
+        """
+        self.atmospheric_transmission = self._set_lists(self._atmo,
+                                                        'atmospheric_'
+                                                        'transmission')
+        self.throughput *= self.atmospheric_transmission
+
+    def snr(self, npix=1 * u.pixel,
+            n_background=np.inf * u.pixel,
+            background=0 * (u.ct / u.pixel),
+            darkcurrent=0 * (u.ct / u.pixel),
+            readnoise=0 * (u.ct / u.pixel),
+            gain=0 * (u.ct / u.adu),
+            ad_err=AD_ERR_DEFAULT):
+        """
+        A method to return the signal to noise ratio of the observation.
+        For a complete list of parameters and their default values,
+        see :func: `synphot.observe.ccd_snr`.
+
+        Returns
+        -------
+        snr : `~astropy.units.quantity.Quantity`
+        """
+        return ccd_snr(self.countrate * self.exptime, npix=npix,
+                       n_background=n_background, background=background,
+                       darkcurrent=darkcurrent, readnoise=readnoise,
+                       gain=gain, ad_err=ad_err)
+
+    def required_exptime(self, desired_snr, npix=1 * u.pixel,
+                         n_background=np.inf * u.pixel,
+                         background_rate=0 * (u.ct / u.pixel / u.s),
+                         darkcurrent_rate=0 * (u.ct / u.pixel / u.s),
+                         readnoise=0 * (u.ct / u.pixel),
+                         gain=1 * (u.ct / u.adu),
+                         ad_err=AD_ERR_DEFAULT):
+        """
+        A method to return the exposure time needed to obtain a
+        desired signal to noise ratio for this observation. For a complete
+        list of parameters and their default values, see
+        :func: `synphot.observe.exptime_from_ccd_snr`.
+
+        Parameters
+        ----------
+        desired_snr : int or float
+
+        Returns
+        -------
+        required_exptime : `~astropy.units.quantity.Quantity`
+        """
+        return exptime_from_ccd_snr(desired_snr, self.countrate,
+                                    npix=npix, n_background=n_background,
+                                    background_rate=background_rate,
+                                    darkcurrent_rate=darkcurrent_rate,
+                                    readnoise=readnoise, gain=gain,
+                                    ad_err=AD_ERR_DEFAULT)
+
+
+@u.quantity_input(waves=u.angstrom, frac=u.Unit(''))
+def _call_SpecElement_4list(waves, frac):
+    """ Returns a SpectralElement for the given points and values. """
+    return SpectralElement(Empirical1D, points=waves, lookup_table=frac)

--- a/synphot/experimental/observation.py
+++ b/synphot/experimental/observation.py
@@ -1,0 +1,939 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""This module defines an observed spectrum, i.e., a source spectrum
+that has gone through a bandpass.
+
+"""
+
+# STDLIB
+import math
+import warnings
+
+# THIRD-PARTY
+import numpy as np
+
+# ASTROPY
+from astropy import log
+from astropy import units as u
+from astropy.utils.exceptions import (AstropyUserWarning,
+                                      AstropyDeprecationWarning)
+
+# LOCAL
+from synphot import binning, exceptions, units, utils
+from synphot.models import Empirical1D
+from synphot.spectrum import (BaseSourceSpectrum, SourceSpectrum,
+                              SpectralElement)
+
+__all__ = ['Observation', 'ccd_snr', 'exptime_from_ccd_snr']
+
+
+class Observation(BaseSourceSpectrum):
+    """This is an observed spectrum, where a source spectrum
+    has gone through a bandpass.
+
+    Usually, this is the end point of a chain of spectral
+    manipulation. It has extra attributes that deal with binning,
+    which is introduced by the detector.
+
+    Parameters
+    ----------
+    spec : `~synphot.spectrum.SourceSpectrum`
+        Source spectrum.
+
+    band : `~synphot.spectrum.SpectralElement`
+        Bandpass.
+
+    binset : array-like, `~astropy.units.quantity.Quantity`, or `None`
+        Center of binned wavelengths.
+        If not a Quantity, assumed to be in Angstrom.
+        If `None`, input ``self.waveset`` values are used.
+
+    force : {`None`, 'none', 'extrap', 'taper'}
+        Force creation of an observation even when source spectrum
+        and bandpass do not fully overlap:
+
+            * `None` or 'none' - Source must encompass bandpass (default)
+            * 'extrap' - Extrapolate source spectrum (this changes the
+              underlying model of ``spec`` to always extrapolate,
+              if applicable)
+            * 'taper' - Taper source spectrum
+
+    Raises
+    ------
+    synphot.exceptions.DisjointError
+        Bandpass does not overlap with source spectrum.
+
+    synphot.exceptions.PartialOverlap
+        Bandpass only partially overlaps with source spectrum
+        when they must fully overlap.
+
+    synphot.exceptions.SynphotError
+        Invalid inputs.
+
+    synphot.exceptions.UndefinedBinset
+        Missing binned wavelength set.
+
+    """
+    def __init__(self, spec, band, binset=None, force='none'):
+        if not isinstance(spec, SourceSpectrum):
+            raise exceptions.SynphotError('Invalid source spectrum.')
+
+        if not isinstance(band, SpectralElement):
+            raise exceptions.SynphotError('Invalid bandpass.')
+
+        # Inherit input warnings like ASTROLIB PYSYNPHOT
+        warn = {}
+
+        # Validate overlap
+        if force is None:
+            force = 'none'
+        else:
+            force = force.lower()
+        stat = band.check_overlap(spec)
+
+        if stat == 'none':
+            raise exceptions.DisjointError(
+                'Source spectrum and bandpass are disjoint.')
+
+        elif 'partial' in stat:
+
+            if force == 'none':
+                raise exceptions.PartialOverlap(
+                    'Source spectrum and bandpass do not fully overlap. '
+                    'You may use force=[extrap|taper] to force this '
+                    'Observation anyway.')
+
+            elif force == 'taper':
+                spec = spec.taper()
+                msg = 'Source spectrum is tapered.'
+                warnings.warn(msg, AstropyUserWarning)
+                warn['PartialOverlap'] = msg
+
+            elif force.startswith('extrap'):
+                if spec.force_extrapolation():
+                    msg = ('Source spectrum will be extrapolated (at constant '
+                           'value for empirical model).')
+                else:
+                    msg = ('Source spectrum will be evaluated outside '
+                           'pre-defined waveset.')
+
+                warnings.warn(msg, AstropyUserWarning)
+                warn['PartialOverlap'] = msg
+
+            else:
+                raise exceptions.SynphotError(
+                    'force={0} is invalid, must be "none", "taper", '
+                    'or "extrap"'.format(force))
+
+        elif stat != 'full':  # pragma: no cover
+            raise exceptions.SynphotError(
+                'Overlap result of {0} is unexpected'.format(stat))
+
+        # Create composite spectrum
+        super(Observation, self).__init__(spec * band, clean_meta=True)
+        self._spec = spec
+        self._band = band
+        self._force = force
+
+        # Merge in other warnings
+        self.warnings = warn
+
+        # Initialize bins
+        self._init_bins(binset)
+
+    def _init_bins(self, binset):
+        """Calculated binned wavelength centers, edges, and flux.
+
+        By contrast, the native waveset and flux should be considered
+        samples of a continuous function.
+
+        Thus, it makes sense to interpolate ``self.waveset`` and
+        ``self(self.waveset)``, but not `binset` and `binflux`.
+
+        """
+        if binset is None:
+            if self.bandpass.waveset is not None:
+                self._binset = self.bandpass.waveset
+            elif self.spectrum.waveset is not None:
+                self._binset = self.spectrum.waveset
+                log.info('Bandpass waveset is undefined; '
+                         'Using source spectrum waveset instead.')
+            else:
+                raise exceptions.UndefinedBinset(
+                    'Both source spectrum and bandpass have undefined '
+                    'waveset; Provide binset manually.')
+        else:
+            self._binset = self._validate_wavelengths(binset)
+
+        # binset must be in ascending order for calcbinflux()
+        # to work properly.
+        if self._binset[0] > self._binset[-1]:
+            self._binset = self._binset[::-1]
+
+        self._bin_edges = binning.calculate_bin_edges(self._binset)
+
+        # Merge bin edges and centers in with the natural waveset
+        spwave = utils.merge_wavelengths(
+            self._bin_edges.value, self._binset.value)
+        if self.waveset is not None:
+            spwave = utils.merge_wavelengths(spwave, self.waveset.value)
+
+        # Throw out invalid wavelengths after merging.
+        spwave = spwave[spwave > 0]
+
+        # Compute indices associated to each endpoint.
+        indices = np.searchsorted(spwave, self._bin_edges.value)
+        i_beg = indices[:-1]
+        i_end = indices[1:]
+
+        # Prepare integration variables.
+        flux = self(spwave)
+        avflux = (flux.value[1:] + flux.value[:-1]) * 0.5
+        deltaw = spwave[1:] - spwave[:-1]
+
+        # Sum over each bin.
+        binflux, intwave = binning.calcbinflux(
+            self._binset.size, i_beg, i_end, avflux, deltaw)
+
+        self._binflux = binflux * flux.unit
+
+    @property
+    def spectrum(self):
+        """Source spectrum of the observation."""
+        return self._spec
+
+    @property
+    def bandpass(self):
+        """Bandpass of the observation."""
+        return self._band
+
+    @property
+    def binset(self):
+        """Center of binned wavelengths."""
+        return self._binset
+
+    @property
+    def bin_edges(self):
+        """Edges of binned wavelengths."""
+        return self._bin_edges
+
+    @property
+    def binflux(self):
+        """Binned flux corresponding to `binset`."""
+        return self._binflux
+
+    def __mul__(self, other):
+        """Multiply self and other."""
+        sp = self.spectrum * other
+        obs = self.__class__(
+            sp, self.bandpass, binset=self.binset, force=self._force)
+        return obs
+
+    def taper(self, **kwargs):
+        """Tapering is disabled."""
+        raise NotImplementedError('Observation cannot be tapered.')
+
+    def _validate_binned_wavelengths(self, wave):
+        if wave is None:
+            wavelengths = self.binset
+        else:
+            wavelengths = self._validate_wavelengths(wave)
+        return wavelengths
+
+    def sample_binned(self, wavelengths=None, flux_unit=None, **kwargs):
+        """Sample binned observation without interpolation.
+
+        To sample unbinned data, use ``__call__``.
+
+        Parameters
+        ----------
+        wavelengths : array-like, `~astropy.units.quantity.Quantity`, or `None`
+            Wavelength values for sampling.
+            If not a Quantity, assumed to be in Angstrom.
+            If `None`, `binset` is used.
+
+        flux_unit : str or `~astropy.units.core.Unit` or `None`
+            Flux is converted to this unit.
+            If not given, internal unit is used.
+
+        kwargs : dict
+            Keywords acceptable by :func:`~synphot.units.convert_flux`.
+
+        Returns
+        -------
+        flux : `~astropy.units.quantity.Quantity`
+            Binned flux in given unit.
+
+        Raises
+        ------
+        synphot.exceptions.InterpolationNotAllowed
+            Interpolation of binned data is not allowed.
+
+        """
+        x = self._validate_binned_wavelengths(wavelengths)
+        i = np.searchsorted(self.binset, x)
+        if not np.allclose(self.binset[i].value, x.value):
+            raise exceptions.InterpolationNotAllowed(
+                'Some or all wavelength values are not in binset.')
+        y = self.binflux[i]
+
+        if flux_unit is None:
+            flux = y
+        else:
+            flux = units.convert_flux(x, y, flux_unit, **kwargs)
+
+        return flux
+
+    def _get_binned_arrays(self, wavelengths, flux_unit, area=None,
+                           vegaspec=None):
+        """Get binned observation in user units."""
+        x = self._validate_binned_wavelengths(wavelengths)
+        y = self.sample_binned(wavelengths=x, flux_unit=flux_unit, area=area,
+                               vegaspec=vegaspec)
+
+        if isinstance(wavelengths, u.Quantity):
+            w = x.to(wavelengths.unit, u.spectral())
+        else:
+            w = x
+
+        return w, y
+
+    def binned_waverange(self, cenwave, npix, **kwargs):
+        """Calculate the wavelength range covered by the given number
+        of pixels centered on the given central wavelengths of
+        `binset`.
+
+        Parameters
+        ----------
+        cenwave : float or `~astropy.units.quantity.Quantity`
+            Desired central wavelength.
+            If not a Quantity, assumed to be in Angstrom.
+
+        npix : int
+            Desired number of pixels, centered on ``cenwave``.
+
+        kwargs : dict
+            Keywords accepted by :func:`synphot.binning.wave_range`.
+
+        Returns
+        -------
+        waverange : `~astropy.units.quantity.Quantity`
+            Lower and upper limits of the wavelength range,
+            in the unit of ``cenwave``.
+
+        """
+        # Calculation is done in the unit of cenwave.
+        if not isinstance(cenwave, u.Quantity):
+            cenwave = cenwave * self._internal_wave_unit
+
+        bin_wave = units.validate_quantity(
+            self.binset, cenwave.unit, equivalencies=u.spectral())
+
+        return binning.wave_range(
+            bin_wave.value, cenwave.value, npix, **kwargs) * cenwave.unit
+
+    def binned_pixelrange(self, waverange, **kwargs):
+        """Calculate the number of pixels within the given wavelength
+        range and `binset`.
+
+        Parameters
+        ----------
+        waverange : tuple of float or `~astropy.units.quantity.Quantity`
+            Lower and upper limits of the desired wavelength range.
+            If not a Quantity, assumed to be in Angstrom.
+
+        kwargs : dict
+            Keywords accepted by :func:`synphot.binning.pixel_range`.
+
+        Returns
+        -------
+        npix : int
+            Number of pixels.
+
+        """
+        x = units.validate_quantity(
+            waverange, self._internal_wave_unit, equivalencies=u.spectral())
+        return binning.pixel_range(self.binset.value, x.value, **kwargs)
+
+    def effective_wavelength(self, binned=True, wavelengths=None,
+                             mode='efflerg'):
+        """Calculate :ref:`effective wavelength <synphot-formula-effwave>`.
+
+        Parameters
+        ----------
+        binned : bool
+            Sample data in native wavelengths if `False`.
+            Else, sample binned data (default).
+
+        wavelengths : array-like, `~astropy.units.quantity.Quantity`, or `None`
+            Wavelength values for sampling.
+            If not a Quantity, assumed to be in Angstrom.
+            If `None`, ``self.waveset`` or `binset` is used, depending
+            on ``binned``.
+
+        mode : {'efflerg', 'efflphot'}
+            Flux is first converted to the unit below before calculation:
+
+                * 'efflerg' - FLAM
+                * 'efflphot' - PHOTLAM (deprecated)
+
+        Returns
+        -------
+        eff_lam : `~astropy.units.quantity.Quantity`
+            Observation effective wavelength.
+
+        Raises
+        ------
+        synphot.exceptions.SynphotError
+            Invalid mode.
+
+        """
+        mode = mode.lower()
+        if mode == 'efflerg':
+            flux_unit = units.FLAM
+        elif mode == 'efflphot':
+            warnings.warn(
+                'Usage of EFFLPHOT is deprecated.', AstropyDeprecationWarning)
+            flux_unit = units.PHOTLAM
+        else:
+            raise exceptions.SynphotError(
+                'mode must be "efflerg" or "efflphot"')
+
+        if binned:
+            x = self._validate_binned_wavelengths(wavelengths).value
+            y = self.sample_binned(wavelengths=x, flux_unit=flux_unit).value
+        else:
+            x = self._validate_wavelengths(wavelengths).value
+            y = units.convert_flux(x, self(x), flux_unit).value
+
+        num = np.trapz(y * x ** 2, x=x)
+        den = np.trapz(y * x, x=x)
+
+        if den == 0.0:  # pragma: no cover
+            eff_lam = 0.0
+        else:
+            eff_lam = abs(num / den)
+
+        return eff_lam * self._internal_wave_unit
+
+    # https://github.com/spacetelescope/synphot_refactor/issues/159
+    def effstim(self, flux_unit=None, wavelengths=None, area=None,
+                vegaspec=None):
+        """Calculate :ref:`effective stimulus <synphot-formula-effstim>`
+        for given flux unit.
+
+        Parameters
+        ----------
+        flux_unit : str or `~astropy.units.core.Unit` or `None`
+            The unit of effective stimulus.
+            COUNT gives result in count/s (see :meth:`countrate` for more
+            options).
+            If not given, internal unit is used.
+
+        wavelengths : array-like, `~astropy.units.quantity.Quantity`, or `None`
+            Wavelength values for sampling. This must be given if
+            ``self.waveset`` is undefined for the underlying spectrum model(s).
+            If not a Quantity, assumed to be in Angstrom.
+            If `None`, ``self.waveset`` is used.
+
+        area, vegaspec
+            See :func:`~synphot.units.convert_flux`.
+
+        Returns
+        -------
+        eff_stim : `~astropy.units.quantity.Quantity`
+            Observation effective stimulus based on given flux unit.
+
+        """
+        if flux_unit is None:
+            flux_unit = self._internal_flux_unit
+
+        flux_unit = units.validate_unit(flux_unit)
+        flux_unit_name = flux_unit.to_string()
+
+        # Special handling of COUNT/OBMAG.
+        # This is special case of countrate calculations.
+        if flux_unit == u.count or flux_unit_name == units.OBMAG.to_string():
+            val = self.countrate(area, binned=False, wavelengths=wavelengths)
+
+            if flux_unit.decompose() == u.mag:
+                eff_stim = (-2.5 * np.log10(val.value)) * flux_unit
+            else:
+                eff_stim = val
+
+            return eff_stim
+
+        # Special handling of VEGAMAG.
+        # This is basically effstim(self)/effstim(Vega)
+        if flux_unit_name == units.VEGAMAG.to_string():
+            num = self.integrate(wavelengths=wavelengths)
+            den = (vegaspec * self.bandpass).integrate()
+            utils.validate_totalflux(num)
+            utils.validate_totalflux(den)
+            return (2.5 * (math.log10(den.value) -
+                           math.log10(num.value))) * units.VEGAMAG
+
+        # Sample the bandpass
+        x_band = self.bandpass._validate_wavelengths(wavelengths).value
+        y_band = self.bandpass(x_band).value
+
+        # Sample the observation in FLAM
+        inwave = self._validate_wavelengths(wavelengths).value
+        influx = units.convert_flux(inwave, self(inwave), units.FLAM).value
+
+        # Integrate
+        num = abs(np.trapz(inwave * influx, x=inwave))
+        den = abs(np.trapz(x_band * y_band, x=x_band))
+        utils.validate_totalflux(num)
+        utils.validate_totalflux(den)
+        val = (num / den) * units.FLAM
+
+        # Integration should always be done in FLAM and then
+        # converted to desired units as follows.
+        if flux_unit.physical_type == 'spectral flux density wav':
+            if flux_unit == u.STmag:
+                eff_stim = val.to(flux_unit)
+            else:  # FLAM
+                eff_stim = val
+        elif flux_unit.physical_type in (
+                'spectral flux density', 'photon flux density',
+                'photon flux density wav'):
+            w_pivot = self.bandpass.pivot()
+            eff_stim = units.convert_flux(w_pivot, val, flux_unit)
+        else:
+            raise exceptions.SynphotError(
+                'Flux unit {0} is invalid'.format(flux_unit))
+
+        return eff_stim
+
+    def countrate(self, area, binned=True, wavelengths=None, waverange=None,
+                  force=False):
+        """Calculate :ref:`effective stimulus <synphot-formula-effstim>`
+        in count/s.
+
+        Parameters
+        ----------
+        area : float or `~astropy.units.quantity.Quantity`
+            Area that flux covers. If not a Quantity, assumed to be in
+            :math:`cm^{2}`.
+
+        binned : bool
+            Sample data in native wavelengths if `False`.
+            Else, sample binned data (default).
+
+        wavelengths : array-like, `~astropy.units.quantity.Quantity`, or `None`
+            Wavelength values for sampling. This must be given if
+            ``self.waveset`` is undefined for the underlying spectrum model(s).
+            If not a Quantity, assumed to be in Angstrom.
+            If `None`, ``self.waveset`` or `binset` is used, depending
+            on ``binned``.
+
+        waverange : tuple of float, Quantity, or `None`
+            Lower and upper limits of the desired wavelength range.
+            If not a Quantity, assumed to be in Angstrom.
+            If `None`, the full range is used.
+
+        force : bool
+            If a wavelength range is given, partial overlap raises
+            an exception when this is `False` (default). Otherwise,
+            it returns calculation for the overlapping region.
+            Disjoint wavelength range raises an exception regardless.
+
+        Returns
+        -------
+        count_rate : `~astropy.units.quantity.Quantity`
+            Observation effective stimulus in count/s.
+
+        Raises
+        ------
+        synphot.exceptions.DisjointError
+            Wavelength range does not overlap with observation.
+
+        synphot.exceptions.PartialOverlap
+            Wavelength range only partially overlaps with observation.
+
+        synphot.exceptions.SynphotError
+            Calculation failed.
+
+        """
+        # Sample the observation
+        if binned:
+            x = self._validate_binned_wavelengths(wavelengths).value
+            y = self.sample_binned(wavelengths=x, flux_unit=u.count,
+                                   area=area).value
+        else:
+            x = self._validate_wavelengths(wavelengths).value
+            y = units.convert_flux(x, self(x), u.count,
+                                   area=area).value
+
+        # Use entire wavelength range
+        if waverange is None:
+            influx = y
+
+        # Use given wavelength range
+        else:
+            w = units.validate_quantity(waverange, self._internal_wave_unit,
+                                        equivalencies=u.spectral()).value
+            stat = utils.overlap_status(w, x)
+            w1 = w.min()
+            w2 = w.max()
+
+            if stat == 'none':
+                raise exceptions.DisjointError(
+                    'Observation and wavelength range are disjoint.')
+            elif 'partial' in stat:
+                if force:
+                    warnings.warn(
+                        'Count rate calculated only for wavelengths in the '
+                        'overlap between observation and given range.',
+                        AstropyUserWarning)
+                    w1 = max(w1, x.min())
+                    w2 = min(w2, x.max())
+                else:
+                    raise exceptions.PartialOverlap(
+                        'Observation and wavelength range do not fully '
+                        'overlap. You may use force=True to force this '
+                        'calculation anyway.')
+            elif stat != 'full':  # pragma: no cover
+                raise exceptions.SynphotError(
+                    'Overlap result of {0} is unexpected'.format(stat))
+
+            if binned:
+                if wavelengths is None:
+                    bin_edges = self.bin_edges.value
+                else:
+                    bin_edges = binning.calculate_bin_edges(x).value
+                i1 = np.searchsorted(bin_edges, w1) - 1
+                i2 = np.searchsorted(bin_edges, w2)
+                influx = y[i1:i2]
+            else:
+                mask = ((x >= w1) & (x <= w2))
+                influx = y[mask]
+
+        val = math.fsum(influx)
+        utils.validate_totalflux(val)
+
+        return val * (u.count / u.s)
+
+    def plot(self, binned=True, wavelengths=None, flux_unit=None, area=None,
+             vegaspec=None, **kwargs):  # pragma: no cover
+        """Plot the observation.
+
+        .. note:: Uses ``matplotlib``.
+
+        Parameters
+        ----------
+        binned : bool
+            Plot data in native wavelengths if `False`.
+            Else, plot binned data (default).
+
+        wavelengths : array-like, `~astropy.units.quantity.Quantity`, or `None`
+            Wavelength values for sampling.
+            If not a Quantity, assumed to be in Angstrom.
+            If `None`, ``self.waveset`` or `binset` is used, depending
+            on ``binned``.
+
+        flux_unit : str or `~astropy.units.core.Unit` or `None`
+            Flux is converted to this unit for plotting.
+            If not given, internal unit is used.
+
+        area, vegaspec
+            See :func:`~synphot.units.convert_flux`.
+
+        kwargs : dict
+            See :func:`synphot.spectrum.BaseSpectrum.plot`.
+
+        Raises
+        ------
+        synphot.exceptions.SynphotError
+            Invalid inputs.
+
+        """
+        if binned:
+            w, y = self._get_binned_arrays(wavelengths, flux_unit, area=area,
+                                           vegaspec=vegaspec)
+        else:
+            w, y = self._get_arrays(wavelengths, flux_unit=flux_unit,
+                                    area=area, vegaspec=vegaspec)
+        self._do_plot(w, y, **kwargs)
+
+    def as_spectrum(self, binned=True, wavelengths=None):
+        """Reduce the observation to an empirical source spectrum.
+
+        An observation is a complex object with some restrictions
+        on its capabilities. At times, it would be useful to work
+        with the observation as a simple object that is easier to
+        manipulate and takes up less memory.
+
+        This is also useful for writing an observation as sampled
+        spectrum out to a FITS file.
+
+        Parameters
+        ----------
+        binned : bool
+            Write out data in native wavelengths if `False`.
+            Else, write binned data (default).
+
+        wavelengths : array-like, `~astropy.units.quantity.Quantity`, or `None`
+            Wavelength values for sampling.
+            If not a Quantity, assumed to be in Angstrom.
+            If `None`, ``self.waveset`` or `binset` is used, depending
+            on ``binned``.
+
+        Returns
+        -------
+        sp : `~synphot.spectrum.SourceSpectrum`
+            Empirical source spectrum.
+
+        """
+        if binned:
+            w, y = self._get_binned_arrays(
+                wavelengths, self._internal_flux_unit)
+        else:
+            w, y = self._get_arrays(
+                wavelengths, flux_unit=self._internal_flux_unit)
+
+        header = {'observation': str(self), 'binned': binned}
+        return SourceSpectrum(Empirical1D, points=w, lookup_table=y,
+                              meta={'header': header})
+
+
+# See ad_err documentation below.
+AD_ERR_DEFAULT = np.sqrt(0.289) * (u.adu / u.pixel)
+
+
+@u.quantity_input(npix=u.pixel,
+                  n_background=u.pixel,
+                  background=u.ct / u.pixel,
+                  darkcurrent=u.ct / u.pixel,
+                  readnoise=u.ct / u.pixel,
+                  gain=u.ct / u.adu,
+                  ad_err=u.adu / u.pixel)
+def ccd_snr(counts,
+            npix=1 * u.pixel,
+            n_background=np.inf * u.pixel,
+            background=0 * (u.ct / u.pixel),
+            darkcurrent=0 * (u.ct / u.pixel),
+            readnoise=0 * (u.ct / u.pixel),
+            gain=0 * (u.ct / u.adu),
+            ad_err=AD_ERR_DEFAULT):
+    """
+    A function to calculate the idealized theoretical signal to noise ratio
+    (SNR) of an astronomical observation with a given number of counts. This
+    expression is taken from pg 55 of [1]_).
+
+    Parameters
+    ----------
+    counts : `~astropy.units.Quantity`
+        Total number of counts in an arbitrary exposure time with units of
+        either astropy.units.ct, astropy.units.electron, or
+        astropy.units.photon. Be aware that count units may refer to different
+        physical units for different instruments (e.g., one instrument may be
+        "count"ing electrons, while another may be counting analog-to-digital
+        units [ADU]). In the latter case, the user must first multiply their
+        counts by the instrument gain to reflect the correct number of counts
+        for their instrument.
+    npix : `~astropy.units.Quantity`, optional
+        Number of pixels under consideration for the signal with units of
+        pixels. Default is 1 * astropy.units.pixel.
+    n_background : `~astropy.units.Quantity`, optional
+        Number of pixels used in the background estimation with units of
+        pixels. Default is set to np.inf * astropy.units.pixel
+        such that there is no contribution of error due to background
+        estimation. This assumes that n_background will be >> npix.
+    background : `~astropy.units.Quantity`, optional
+        Total photons per pixel due to the background/sky with units of
+        counts/pixel.
+        Default is 0 * astropy.units.ct / astropy.units.pixel.
+    darkcurrent : `~astropy.units.Quantity`, optional
+        Total counts per pixel due to the dark current with units
+        of counts/pixel.
+        Default is 0 * astropy.units.ct / astropy.units.pixel.
+    readnoise : `~astropy.units.Quantity`, optional
+        Counts per pixel from the read noise with units of counts/pixel.
+        Default is 0 * astropy.units.ct / astropy.units.pixel.
+    gain : `~astropy.units.Quantity`, optional
+        Gain of the CCD with units of counts/ADU. Default is
+        0 * astropy.units.ct / astropy.units.adu such that the
+        contribution to the error due to the gain is assumed to be negligable.
+    ad_err : `~astropy.units.Quantity`, optional
+        An estimate of the 1 sigma error within the A/D converter with units of
+        adu/pixel. Default is set to
+        sqrt(0.289) * astropy.units.adu / astropy.units.pixel, where
+        sqrt(0.289) comes from the assumption that "for a charge level that is
+        half way between two output ADU steps, there is an equal chance that it
+        will be assigned to the lower or to the higher ADU value when converted
+        to a digital number" (text from footnote on page 56 of [1]_, see also
+        [2]_).
+
+    References
+    ----------
+    .. [1] Howell, S. B. 2000, *Handbook of CCD Astronomy* (Cambridge, UK:
+        Cambridge University Press)
+    .. [2] Merline, W. & Howell, S. B. *A Realistic Model for Point-sources
+        Imaged on Array Detectors: The Model and Initial Results*. ExA, 6:163
+        (1995)
+
+    Returns
+    -------
+    snr : `~astropy.units.Quantity`
+        The signal to noise ratio of the given observation in dimensionless
+        units.
+    """
+    if counts.unit in (u.electron, u.photon):
+        counts = counts.value * u.ct
+    elif counts.unit != u.ct:
+        raise u.UnitsError('counts must have units of either '
+                           'astropy.units.ct, astropy.units.electron, '
+                           'or astropy.units.photon')
+
+    readnoise = _get_shotnoise(readnoise)
+    gain_err = _get_shotnoise(gain * ad_err)
+
+    pixel_terms = npix * (1 + npix / n_background)
+    detector_noise = (background + darkcurrent +
+                      readnoise ** 2 + gain_err ** 2)
+
+    return (counts / np.sqrt(counts + pixel_terms * detector_noise) /
+            np.sqrt(1 * u.ct))
+
+
+@u.quantity_input(npix=u.pixel,
+                  n_background=u.pixel,
+                  background_rate=u.ct / u.pixel / u.s,
+                  darkcurrent_rate=u.ct / u.pixel / u.s,
+                  readnoise=u.ct / u.pixel,
+                  gain=u.ct / u.adu,
+                  ad_err=u.adu / u.pixel)
+def exptime_from_ccd_snr(snr, countrate,
+                         npix=1 * u.pixel,
+                         n_background=np.inf * u.pixel,
+                         background_rate=0 * (u.ct / u.pixel / u.s),
+                         darkcurrent_rate=0 * (u.ct / u.pixel / u.s),
+                         readnoise=0 * (u.ct / u.pixel),
+                         gain=1 * (u.ct / u.adu),
+                         ad_err=AD_ERR_DEFAULT):
+    """
+    Returns the exposure time needed in units of seconds to achieve
+    the specified (idealized theoretical) signal to noise ratio
+    (from pg 57-58 of [1]_).
+
+    Parameters
+    ----------
+    snr : float, int, or `~astropy.units.Quantity`
+        The signal to noise ratio of the given observation in dimensionless
+        units.
+    countrate : `~astropy.units.Quantity`
+        The counts per second with units of (either astropy.units.ct,
+        astropy.units.electron or astropy.units.photon) / astropy.units.s.
+        Be aware that count units may refer to different physical units for
+        different instruments (e.g. one instrument may be "count"ing
+        electrons, while another may be counting analog-to-digital
+        units [ADU]). In the latter case, the user must first multiply their
+        counts by the instrument gain to reflect the correct number of counts
+        for their instrument.
+    npix : `~astropy.units.Quantity`, optional
+        Number of pixels under consideration for the signal with units of
+        pixels. Default is 1 * astropy.units.pixel.
+    n_background : `~astropy.units.Quantity`, optional
+        Number of pixels used in the background estimation with units of
+        pixels. Default is set to np.inf * astropy.units.pixel
+        such that there is no contribution of error due to background
+        estimation. This assumes that n_background will be >> npix.
+    background_rate : `~astropy.units.Quantity`, optional
+        Photons per pixel per second due to the backround/sky with units of
+        counts/second/pixel.
+        Default is 0 * (astropy.units.ct /
+        astropy.units.second / astropy.units.pixel)
+    darkcurrent_rate : `~astropy.units.Quantity`, optional
+        Counts per pixel per second due to the dark current with units
+        of counts/second/pixel.
+        Default is 0 * (astropy.units.ct /
+        astropy.units.second / astropy.units.pixel)
+    readnoise : `~astropy.units.Quantity`, optional
+        Counts per pixel from the read noise with units of counts/pixel.
+        Default is 0 * astropy.units.ct / astropy.units.pixel.
+    gain : `~astropy.units.Quantity`, optional
+        Gain of the CCD with units of counts/ADU. Default is
+        1 * astropy.units.ct / astropy.units.adu such that the
+        contribution to the error due to the gain is assumed to be small.
+    ad_err : `~astropy.units.Quantity`, optional
+        An estimate of the 1 sigma error within the A/D converter with units of
+        adu/pixel. Default is set to
+        sqrt(0.289) * astropy.units.adu / astropy.units.pixel, where
+        sqrt(0.289) comes from the assumption that "for a charge level that is
+        half way between two output ADU steps, there is an equal chance that it
+        will be assigned to the lower or to the higher ADU value when converted
+        to a digital number" (text from footnote on page 56 of [1]_, see also
+        [2]_).
+
+    References
+    ----------
+    .. [1] Howell, S. B. 2000, *Handbook of CCD Astronomy* (Cambridge, UK:
+        Cambridge University Press)
+    .. [2] Merline, W. & Howell, S. B. *A Realistic Model for Point-sources
+        Imaged on Array Detectors: The Model and Initial Results*. ExA, 6:163
+        (1995)
+
+    Returns
+    -------
+    t : `~astropy.units.Quantity`
+        The exposure time needed (in seconds) to achieve the given signal
+        to noise ratio.
+    """
+    if countrate.unit in (u.electron / u.s, u.photon / u.s):
+        countrate = countrate.value * (u.ct / u.s)
+    elif countrate.unit != u.ct / u.s:
+        raise u.UnitsError('countrate must have units of (either '
+                           'astropy.units.ct, astropy.units.electron, or '
+                           'astropy.units.photon) / astropy.units.s')
+
+    # necessary for units to work:
+    snr = snr * np.sqrt(1 * u.ct)
+    readnoise = _get_shotnoise(readnoise)
+    gain_err = _get_shotnoise(gain * ad_err)
+
+    # solve t with the quadratic equation (pg. 57 of Howell 2000)
+    A = countrate ** 2
+    B = (-1) * snr ** 2 * (countrate + npix * (background_rate +
+                                               darkcurrent_rate))
+    C = (-1) * snr ** 2 * npix * readnoise ** 2
+
+    t = (-B + np.sqrt(B ** 2 - 4 * A * C)) / (2 * A)
+
+    if gain_err.value > 1 or np.isfinite(n_background.value):
+        from scipy.optimize import fsolve
+        # solve t numerically
+        t = fsolve(_t_with_small_errs, t, args=(background_rate,
+                                                darkcurrent_rate,
+                                                gain_err, readnoise, countrate,
+                                                npix, n_background))
+        t = float(t) * u.s
+
+    return t
+
+
+def _get_shotnoise(detector_property):
+    """
+    Returns the shot noise (i.e. non-Poissonion noise) in the correct
+    units. ``detector_property`` must be a Quantity.
+    """
+    # Ensure detector_property is in the correct units:
+    detector_property = detector_property.to(u.ct / u.pixel)
+    return detector_property.value * np.sqrt(1 * (u.ct / u.pixel))
+
+
+def _t_with_small_errs(t, background_rate, darkcurrent_rate, gain_err,
+                       readnoise, countrate, npix, n_background):
+    """
+    Returns the full expression for the exposure time including the
+    contribution to the noise from the background and the gain.
+    """
+    if not hasattr(t, 'unit'):
+        t = t * u.s
+
+    detector_noise = (background_rate * t + darkcurrent_rate * t +
+                      gain_err ** 2 + readnoise ** 2)
+    radicand = countrate * t + (npix * (1 + npix / n_background) *
+                                detector_noise)
+
+    return countrate * t / np.sqrt(radicand)

--- a/synphot/experimental/skymodel.py
+++ b/synphot/experimental/skymodel.py
@@ -1,0 +1,202 @@
+import os
+import json
+import requests
+
+import astropy.units as u
+from astropy.io import fits
+
+
+def atmospheric_transmittance(airmass=1.0, pwv_mode='pwv', season=0,
+                              time=0, pwv=3.5, msolflux=130.0,
+                              incl_moon='Y', moon_sun_sep=90.0,
+                              moon_target_sep=45.0, moon_alt=45.0,
+                              moon_earth_dist=1.0, incl_starlight='Y',
+                              incl_zodiacal='Y',
+                              ecl_lon=135.0, ecl_lat=90.0,
+                              incl_loweratm='Y', incl_upperatm='Y',
+                              incl_airglow='Y', incl_therm='N',
+                              therm_t1=0.0, therm_e1=0.0,
+                              therm_t2=0.0, therm_e2=0.0, therm_t3=0.0,
+                              therm_e3=0.0, vacair='vac', wmin=300.0,
+                              wmax=2000.0,
+                              wgrid_mode='fixed_wavelength_step',
+                              wdelta=0.1, wres=20000, lsf_type='none',
+                              lsf_gauss_fwhm=5.0, lsf_boxcar_fwhm=5.0,
+                              observatory='paranal'):
+    """
+    Returns the model atmospheric transmittance curve queried from the SkyCalc
+    Sky Model Calculator. The default parameters used here are the default
+    parameters provided by SkyCalc:
+    http://www.eso.org/observing/etc/doc/skycalc/skycalc_defaults.txt
+
+    Parameters
+    ----------
+    airmass: float (range [1.0,3.0])
+        Airmass. Alt and airmass are coupled through the plane parallel
+        approximation airmass=sec(z), z being the zenith distance
+        z=90°−Alt
+    pwv_mode: str
+        options: ['pwv','season'] (default is 'pwv')
+    season: int
+        Time of year if not in pwv mode.
+        options: [0,1,2,3,4,5,6] (default is 0)
+        (0 = all year, 1 = dec/jan, 2 = feb/mar...)
+    time: int
+        Period of night. options: [0,1,2,3] (default is 0)
+        (0 = all year, 1, 2, 3 = third of night)
+    pwv: float
+        Precipitable Water Vapor (default is 3.5).
+        options: [-1.0,0.5,1.0,1.5,2.5,3.5,5.0,7.5,10.0,20.0]
+    msolflux: float
+        Monthly Averaged Solar Flux, s.f.u float > 0 (default is 130.0)
+    incl_moon: str
+        Flag for inclusion of scattered moonlight. options = ['Y', 'N']
+        (default is 'Y')
+        Moon coordinate constraints: |z – zmoon| ≤ ρ ≤ |z + zmoon| where
+        ρ=moon/target separation, z=90°−target altitude and
+        zmoon=90°−moon altitude.
+    moon_sun_sep: float
+        Degrees of separation between Sun and Moon as seen from Earth
+        (i.e. the "moon phase").
+        options: [0.0,360.0] (default is 90.0)
+    moon_target_sep: float
+        Moon-Target Separation ( ρ )
+        Degrees in range [0.0,180.0] (defualt is 45.0)
+            # degrees float range [-90.0,90.0] Moon Altitude over Horizon
+    moon_alt: float
+        Moon Altitude over Horizon. Degrees in range [-90.0,90.0]
+        (default is 45.0)
+    moon_earth_dist: float
+        Moon-Earth Distance (mean=1) in range [0.91,1.08]
+        (default is 1.0)
+    incl_starlight: str
+        Flag for inclusion of scattered starlight.
+        options: ['Y', 'N'] (default is 'Y')
+    incl_zodiacal: str
+        Flag for inclusion of zodiacal light.
+        options: ['Y', 'N'] (default is 'Y')
+    ecl_lon: float
+        Heliocentric ecliptic in degree range [-180.0,180.0].
+        (default is 135.0)
+    ecl_lat: float
+        Ecliptic latitude in degree range [-90.0,90.0].
+        (default is 90.0)
+
+    incl_loweratm: str
+        Flag for inclusion of molecular emission of lower atmosphere.
+        options: ['Y', 'N'] (default is 'Y')
+    incl_upperatm: str
+        Flag for inclusion of molecular emission of upper atmosphere.
+        options: ['Y', 'N'] (default is 'Y')
+    incl_airglow: str
+        Flag for inclusion of airglow continuum (residual continuum)
+        options: ['Y', 'N'] (default is 'Y')
+
+    incl_therm: str
+        Flag for inclusion of instrumental thermal radiation.
+        options: ['Y', 'N'] (default is 'N')
+        Note: This radiance component represents an instrumental effect.
+        The emission is provided relative to the other model components.
+        To obtain the correct absolute flux, an instrumental response curve
+        must be applied to the resulting model spectrum.
+        See section 6.2.4 in the SkyCalc documentation at
+        http://localhost/observing/etc/doc/skycalc/
+        The_Cerro_Paranal_Advanced_Sky_Model.pdf
+    therm_t1, therm_t2, therm_t3 : float
+        Temperature in K (default is 0.0)
+    therm_e1, therm_e2, therm_e3: float
+        In range [0,1] (default is 0.0)
+
+    vacair: str
+        In regards to the wavelength grid.
+        options: ['vac', 'air] (default is 'vac')
+    wmin: float
+        Minimum wavelength (nm) in the wavelength grid.
+        Must be in range [300.0,30000.0] and < wmax
+        (default is 300.0)
+    wmax: float
+        Maximum wavelength (nm) in the wavelength grid.
+        Must be in range [300.0,30000.0] and > wmin
+        (default is 2000.0)
+    wgrid_mode: str
+        Mode of the wavelength grid.
+        options: ['fixed_spectral_resolution','fixed_wavelength_step', 'user']
+        (default is 'fixed_wavelength_step')
+    wdelta: float
+        Wavelength sampling step dlam in range [0,30000.0] (nm/step)
+        (default is 0.1)
+    wres: int
+        lam/dlam where dlam is wavelength step.
+        In range [0,1.0e6] (default is 20000)
+    wgrid_user: list of floats
+        default is [500.0, 510.0, 520.0, 530.0, 540.0, 550.0]
+
+    lsf_type: str
+        Line spread function type for convolution.
+        options: ['none','Gaussian','Boxcar'] (default is 'none')
+    lsf_gauss_fwhm: float
+        Gaussian full-width half-max for line spread function wavelength bins.
+        Range > 0.0 (default is 5.0)
+    lsf_boxcar_fwhm: float
+        Boxcar full-width half-max for line spread function wavelength bins.
+        Range > 0.0 (default is 5.0)
+
+    observatory: str
+        Observatory where observation takes place.
+        Options are 'paranal', 'lasilla', 'armazones' (default is 'paranal')
+
+    Returns
+    -------
+    trans_waves, transmission: tuple of arrays of floats
+        'trans_waves' is an array of wavelengths in angstroms (float),
+        'transmission' is an array of fractional atmospheric
+        transmittance (float).
+
+    """
+
+    params = locals()
+
+    if params['observatory'] == 'lasilla':
+        params['observatory'] = '2400'
+    elif params['observatory'] == 'paranal':
+        params['observatory'] = '2640'
+    elif (params['observatory'] == '3060m' or
+          params['observatory'] == 'armazones'):
+        params['observatory'] = '3060'
+    else:
+        raise ValueError('Wrong Observatory name, please refer to the '
+                         'skycalc_cli documentation.')
+
+    # Use the bit from skycalc_cli which queries from the SkyCalc Sky Model
+    server = 'http://etimecalret-001.eso.org'
+    url = server + '/observing/etc/api/skycalc'
+    response = requests.post(url, data=json.dumps(params))
+    results = json.loads(response.text)
+
+    status = results['status']
+    tmpdir = results['tmpdir']
+    tmpurl = server + '/observing/etc/tmp/' + tmpdir + '/skytable.fits'
+
+    if status == 'success':
+        try:
+            response = requests.get(tmpurl, stream=True)
+            data = response.content
+        except requests.exceptions.RequestException as e:
+            print(e, 'could not retrieve FITS data from server')
+    else:
+        print('HTML request failed', results)
+
+    # Create a temporary file to write the binary results to
+    tmp_data_file = './tmp_skycalc_data.fits'
+
+    with open(tmp_data_file, 'wb') as f:
+        f.write(data)
+
+    hdu = fits.open(tmp_data_file)
+    trans_waves = hdu[1].data["LAM"] * u.um  # wavelengths
+    transmission = hdu[1].data["TRANS"]
+
+    # Delete the file after reading from it
+    os.remove(tmp_data_file)
+
+    return trans_waves.to(u.angstrom), transmission

--- a/synphot/experimental/tests/test_exposure.py
+++ b/synphot/experimental/tests/test_exposure.py
@@ -1,0 +1,54 @@
+from synphot.models import BlackBody1D
+from synphot.spectrum import SourceSpectrum, SpectralElement
+from synphot.experimental.exposure import Exposure
+import astropy.units as u
+import numpy as np
+
+
+class TestExposure(object):
+    """ Tests that each possible bandpass input returns a
+    SpectralElement object """
+    def setup_class(self):
+        self.source_spec = SourceSpectrum(BlackBody1D, temperature=6000 * u.K)
+        self.diameter = 1 * u.m
+        self.exptime = 1 * u.s
+        test_waves = np.arange(300, 1000) * u.nm
+        test_trans = np.linspace(0, 1, len(test_waves)) * u.Unit('')
+        self.test_throughput_list = [test_waves, test_trans]
+
+    def test_bandpass_str(self):
+        bp = 'johnson_u'
+        result = Exposure(self.source_spec, self.diameter, self.exptime,
+                          bandpass=bp).bandpass
+        assert type(result) == SpectralElement
+
+    def test_bandpass_list(self):
+        result = Exposure(self.source_spec, self.diameter, self.exptime,
+                          bandpass=self.test_throughput_list).bandpass
+        assert type(result) == SpectralElement
+
+        bp_flipped = [self.test_throughput_list[1],
+                      self.test_throughput_list[0]]
+        result_flipped = Exposure(self.source_spec, self.diameter,
+                                  self.exptime, bandpass=bp_flipped).bandpass
+        assert type(result_flipped) == SpectralElement
+
+    def test_qe(self):
+        result = Exposure(self.source_spec, self.diameter, self.exptime,
+                          quantum_efficiency=self.test_throughput_list
+                          ).quantum_efficiency
+
+        assert type(result) == SpectralElement
+
+    def test_atmosphere(self):
+        result = Exposure(self.source_spec, self.diameter, self.exptime,
+                          atmospheric_transmission=self.test_throughput_list
+                          ).atmospheric_transmission
+
+        assert type(result) == SpectralElement
+
+    def test_snr(self):
+        """ unfinished """
+        result = Exposure(self.source_spec, self.diameter, self.exptime,
+                          force='extrap').snr
+        return result

--- a/synphot/experimental/tests/test_observation.py
+++ b/synphot/experimental/tests/test_observation.py
@@ -1,0 +1,580 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Test observation.py module."""
+
+# STDLIB
+import os
+
+# THIRD-PARTY
+import numpy as np
+import pytest
+
+# ASTROPY
+from astropy import units as u
+from astropy.modeling.models import Const1D
+from astropy.tests.helper import (catch_warnings, assert_quantity_allclose,
+                                  raises)
+from astropy.utils import minversion
+from astropy.utils.data import get_pkg_data_filename
+from astropy.utils.exceptions import AstropyDeprecationWarning
+
+# LOCAL
+from .test_units import _area
+from .. import exceptions, units
+from ..models import (BlackBodyNorm1D, Box1D, ConstFlux1D, Empirical1D,
+                      GaussianFlux1D)
+from ..observation import Observation, ccd_snr, exptime_from_ccd_snr
+from ..spectrum import SourceSpectrum, SpectralElement
+
+try:
+    import scipy
+except ImportError:
+    HAS_SCIPY = False
+else:
+    HAS_SCIPY = True
+
+HAS_SCIPY = HAS_SCIPY and minversion(scipy, '0.14')
+
+# Global test data files
+_specfile = get_pkg_data_filename(
+    os.path.join('data', 'grw_70d5824_stisnic_005.fits'))
+_bandfile = get_pkg_data_filename(
+    os.path.join('data', 'hst_acs_hrc_f555w.fits'))
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+class TestObservation(object):
+    """Test Observation (most of them)."""
+    def setup_class(self):
+        sp = SourceSpectrum(
+            ConstFlux1D, amplitude=1 * units.FLAM,
+            meta={'warnings': {'w1': 'spec warn', 'w2': 'foo'}})
+        bp = SpectralElement.from_file(_bandfile)
+        bp.warnings = {'w1': 'band warn'}
+        w = np.arange(1000, 11001, dtype=np.float64)
+        self.obs = Observation(sp, bp, binset=w)
+
+    def test_invalid_input_spec(self):
+        with pytest.raises(exceptions.SynphotError):
+            Observation(self.obs.bandpass, self.obs.bandpass)
+        with pytest.raises(exceptions.SynphotError):
+            Observation(self.obs.spectrum, self.obs.spectrum)
+
+    def test_inherit_warnings(self):
+        assert sorted(self.obs.warnings) == ['w1', 'w2']
+        assert self.obs.warnings['w1'] == 'band warn'
+
+    def test_disjoint_spec(self):
+        """The rest of overlap logic is tested in `TestInitWithForce`."""
+        sp = SourceSpectrum(
+            Empirical1D, points=[39999.9, 40000, 40001, 40001.1],
+            lookup_table=[0, 1, 1, 0])
+        with pytest.raises(exceptions.DisjointError):
+            Observation(sp, self.obs.bandpass)
+
+    def test_taper(self):
+        with pytest.raises(NotImplementedError):
+            self.obs.taper()
+
+    def test_binned_data(self):
+        # Binned flux
+        np.testing.assert_array_equal(self.obs.binflux[:10], 0)
+        np.testing.assert_array_equal(self.obs.binflux[-10:], 0)
+        np.testing.assert_allclose(
+            self.obs.sample_binned(wavelengths=self.obs.binset[5000:5010],
+                                   flux_unit=units.FLAM).value,
+            [0.12265425, 0.12226972, 0.12184207, 0.12141429, 0.12098646,
+             0.1205586, 0.1201307, 0.11970269, 0.11927488, 0.11884699],
+            rtol=1e-4)
+
+        # Binned wave and flux
+        w, y = self.obs._get_binned_arrays(
+            [599.9999999999, 600.4, 600.9] * u.nm, units.FLAM)
+        np.testing.assert_allclose(w.value, [600, 600.4, 600.9])
+        np.testing.assert_allclose(
+            y.value, [0.12265425, 0.12098646, 0.11884699], rtol=1e-4)
+
+        w, y = self.obs._get_binned_arrays(None, units.PHOTLAM)
+        np.testing.assert_array_equal(w, self.obs.binset)
+        np.testing.assert_array_equal(y, self.obs.binflux)
+
+        # Bin edges
+        np.testing.assert_array_equal(
+            self.obs.bin_edges.value[:10],
+            [999.5, 1000.5, 1001.5, 1002.5, 1003.5, 1004.5, 1005.5, 1006.5,
+             1007.5, 1008.5])
+        np.testing.assert_array_equal(
+            self.obs.bin_edges.value[5000:5010],
+            [5999.5, 6000.5, 6001.5, 6002.5, 6003.5, 6004.5, 6005.5, 6006.5,
+             6007.5, 6008.5])
+        np.testing.assert_array_equal(
+            self.obs.bin_edges.value[-10:],
+            [10991.5, 10992.5, 10993.5, 10994.5, 10995.5, 10996.5, 10997.5,
+             10998.5, 10999.5, 11000.5])
+
+    def test_reversed_binset(self):
+        obs2 = Observation(
+            self.obs.spectrum, self.obs.bandpass, binset=self.obs.binset[::-1])
+        np.testing.assert_array_equal(obs2.binset, self.obs.binset)
+        np.testing.assert_array_equal(obs2.binflux, self.obs.binflux)
+        np.testing.assert_array_equal(obs2.bin_edges, self.obs.bin_edges)
+
+    def test_sampled_binned_exceptions(self):
+        with pytest.raises(exceptions.InterpolationNotAllowed):
+            self.obs.sample_binned([6000, 6004.5, 6009])
+        with pytest.raises(exceptions.UnsortedWavelength):
+            self.obs.sample_binned([6004, 6000, 6009])
+
+    @pytest.mark.parametrize(
+        ('cenwave', 'ans'),
+        [(500 * u.nm, [499.9, 500.1] * u.nm),
+         (5000, [4999, 5001] * u.AA)])
+    def test_binned_waverange(self, cenwave, ans):
+        w = self.obs.binned_waverange(cenwave, 2, mode='none')
+        np.testing.assert_allclose(w, ans)
+
+    def test_binned_pixelrange(self):
+        w = [499.95, 500.05] * u.nm
+        assert self.obs.binned_pixelrange(w, mode='round') == 1
+
+    def test_default_binset_from_bandpass(self):
+        obs2 = Observation(self.obs.spectrum, self.obs.bandpass)
+        np.testing.assert_array_equal(obs2.binset, self.obs.bandpass.waveset)
+
+    def test_default_binset_from_spectrum(self):
+        tf_unit = u.erg / (u.cm * u.cm * u.s)
+        sp = SourceSpectrum(
+            GaussianFlux1D, mean=5000, total_flux=(1 * tf_unit), fwhm=10)
+        bp = SpectralElement(Const1D, amplitude=1)
+        obs2 = Observation(sp, bp, force='extrap')
+        np.testing.assert_array_equal(obs2.binset, sp.waveset)
+
+    def test_undefined_binset(self):
+        bp = SpectralElement(Const1D, amplitude=1)
+        with pytest.raises(exceptions.UndefinedBinset):
+            Observation(self.obs.spectrum, bp)
+
+    def test_as_spectrum(self):
+        w = np.arange(6000, 6005)
+        sp1 = self.obs.as_spectrum(binned=True, wavelengths=w)  # Binned
+        sp2 = self.obs.as_spectrum(binned=False, wavelengths=w)  # Sampled
+        np.testing.assert_allclose(
+            sp1(sp1.waveset), sp2(sp2.waveset), rtol=1e-3)
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+class TestInitWithForce(object):
+    """Test forced initialization."""
+    def setup_class(self):
+        x = np.arange(3000, 4000)
+        y = np.ones_like(x) * 0.75
+        self.sp = SourceSpectrum(
+            Empirical1D, points=x, lookup_table=y, meta={'expr': 'short flat'})
+        self.bp = SpectralElement(
+            Empirical1D, points=[3949.9, 3950, 4050, 4050.1],
+            lookup_table=[0, 1, 1, 0])
+
+    @pytest.mark.parametrize(
+        ('force_type', 'ans'),
+        [('taper', 0),
+         ('extrap', 0.75)])
+    def test_force(self, force_type, ans):
+        obs = Observation(self.sp, self.bp, force=force_type)
+        assert obs(4005).value == ans
+        assert force_type in obs.warnings['PartialOverlap']
+
+    def test_exceptions(self):
+        with pytest.raises(exceptions.PartialOverlap):
+            Observation(self.sp, self.bp)
+        with pytest.raises(exceptions.SynphotError):
+            Observation(self.sp, self.bp, force='foo')
+
+
+class TestMathOperators(object):
+    """Test Observation math operators."""
+    def setup_class(self):
+        sp = SourceSpectrum(ConstFlux1D, amplitude=1)
+        bp = SpectralElement(Box1D, amplitude=1, x_0=5000, width=100)
+        w = np.arange(1000, 10000)
+        self.obs = Observation(sp, bp, binset=w)
+
+    @pytest.mark.parametrize('is_scalar', [True, False])
+    def test_mul(self, is_scalar):
+        if is_scalar:
+            other = 2
+        else:
+            other = SpectralElement(Const1D, amplitude=2)
+
+        obs2 = self.obs * other
+        np.testing.assert_allclose(obs2([1000, 5000]).value, [0, 2])
+        np.testing.assert_allclose(
+            obs2.sample_binned([4000, 4999]).value, [0, 2])
+
+    def test_div(self):
+        with pytest.raises(NotImplementedError):
+            self.obs / 2
+
+    def test_addsub(self):
+        with pytest.raises(NotImplementedError):
+            self.obs + self.obs
+        with pytest.raises(NotImplementedError):
+            self.obs - self.obs
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+class TestObsPar(object):
+    """Test Observation values from IRAF SYNPHOT CALCPHOT,
+    unless noted otherwise.
+
+    """
+    def setup_class(self):
+        sp = SourceSpectrum.from_file(_specfile)
+        bp = SpectralElement.from_file(_bandfile)
+        self.obs = Observation(sp, bp)
+
+    def test_avglam(self):
+        """Tested for PHOTLAM only; no binning."""
+        np.testing.assert_allclose(
+            self.obs.avgwave().value, 5321.091, rtol=1e-5)
+
+    def test_barlam(self):
+        """Tested for PHOTLAM only; no binning."""
+        np.testing.assert_allclose(
+            self.obs.barlam().value, 5286.685, rtol=1e-5)
+
+    def test_pivot(self):
+        """Tested with value from ASTROLIB PYSYNPHOT; no binning."""
+        np.testing.assert_allclose(self.obs.pivot().value, 5309.578, rtol=1e-5)
+
+    def test_normalize(self):
+        """Tested with value from ASTROLIB PYSYNPHOT; no binning."""
+        obs2 = self.obs.normalize(1 * units.PHOTLAM, band=self.obs.bandpass)
+        np.testing.assert_allclose(
+            obs2.countrate(_area).value, 59517756.384, rtol=1e-5)
+
+    @pytest.mark.parametrize('binned', [True, False])
+    def test_efflam(self, binned):
+        with catch_warnings(AstropyDeprecationWarning) as w:
+            x = self.obs.effective_wavelength(mode='efflphot', binned=binned)
+            assert len(w) == 1
+            assert str(w[0].message) == 'Usage of EFFLPHOT is deprecated.'
+
+        np.testing.assert_allclose(x.value, 5344.312, rtol=1e-4)
+
+    @pytest.mark.parametrize('binned', [True, False])
+    def test_efflam_erg(self, binned):
+        np.testing.assert_allclose(
+            self.obs.effective_wavelength(mode='efflerg', binned=binned).value,
+            5321.091, rtol=1e-4)
+
+    def test_efflam_exception(self):
+        with pytest.raises(exceptions.SynphotError):
+            self.obs.effective_wavelength(mode='foo')
+
+    # ans taken from calculating effstim in FLAM and then using unit
+    # conversion around bandpass pivot wavelength.
+    @pytest.mark.parametrize(
+        ('flux_unit', 'ans'),
+        [(units.FLAM, 3.05131543e-14),
+         (units.FNU, 2.91961387e-25),
+         (None, 0.00822697),
+         (units.PHOTLAM, 0.00822697),
+         (units.PHOTNU, 7.8718752e-14),
+         (u.Jy, 0.02919614),
+         (u.mJy, 29.19613866)])
+    def test_effstim(self, flux_unit, ans):
+        """Test EFFSTIM for all supported non-mag and non-count flux units."""
+        np.testing.assert_allclose(
+            self.obs.effstim(flux_unit=flux_unit).value, ans)
+
+    def test_effstim_count(self):
+        """Test EFFSTIM in count and OBMAG separately due to different API
+        and tolerance.
+
+        .. note::
+
+            ``binned``, ``waverange``, and ``force`` tested in `TestCountRate`.
+
+        """
+        # pysynphot 0.9.12.dev5
+        ans_ct = 101462.39601864747
+        ans_ob = -12.515762784747238
+        tol = 1e-4
+
+        val_ct = self.obs.effstim(flux_unit=u.count, area=_area).value
+        np.testing.assert_allclose(val_ct, ans_ct, rtol=tol)
+
+        val_ob = self.obs.effstim(flux_unit=units.OBMAG, area=_area).value
+        np.testing.assert_allclose(val_ob, ans_ob, atol=tol, rtol=0)
+
+        # Sanity check
+        np.testing.assert_allclose(val_ob, -2.5 * np.log10(val_ct))
+
+    # ans taken from calculating effstim in FLAM and then using unit
+    # conversion around bandpass pivot wavelength.
+    @pytest.mark.parametrize(
+        ('flux_unit', 'ans'),
+        [(u.STmag, 12.68878224),
+         (u.ABmag, 12.73668646)])
+    def test_effstim_mag(self, flux_unit, ans):
+        """Test mag separately because tolerance calculation, if needed,
+        is different."""
+        np.testing.assert_allclose(
+            self.obs.effstim(flux_unit=flux_unit, area=_area).value, ans)
+
+    def test_effstim_analytic(self):
+        sp = SourceSpectrum(BlackBodyNorm1D, temperature=5000)
+        bp = SpectralElement(Box1D, amplitude=1, x_0=5500, width=1)
+        obs = Observation(sp, bp)
+        np.testing.assert_allclose(
+            obs.effstim(flux_unit=units.FLAM).value, 2.03E-15, rtol=0.01)  # 1%
+
+    @pytest.mark.remote_data
+    def test_effstim_vegamag(self):
+        ans = 12.737293324241517  # pysynphot 0.9.12.dev5
+        vspec = SourceSpectrum.from_vega()
+        np.testing.assert_allclose(
+            self.obs.effstim(flux_unit=units.VEGAMAG, vegaspec=vspec).value,
+            ans)
+
+    @pytest.mark.parametrize('flux_unit', [u.mag, units.VEGAMAG])
+    def test_effstim_exceptions(self, flux_unit):
+        with pytest.raises(exceptions.SynphotError):
+            self.obs.effstim(flux_unit=flux_unit)
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+class TestCountRate(object):
+    """Test countrate with Observation with well-defined ranges.
+
+    .. note:: Use binned data except for :func:`test_waverange_no_bin`.
+
+    """
+    def setup_class(self):
+        x = np.arange(1000, 1100, 0.5)
+        y = units.convert_flux(
+            x, (x - 1000) * u.count, units.PHOTLAM, area=_area).value
+        sp = SourceSpectrum(Empirical1D, points=x, lookup_table=y,
+                            meta={'expr': 'slope1'})
+        bp = SpectralElement(
+            Empirical1D, points=[1009.95, 1010, 1030, 1030.05],
+            lookup_table=[0, 1, 1, 0], meta={'expr': 'handmade_box'})
+        self.obs = Observation(sp, bp, binset=np.arange(1000, 1020))
+
+    @pytest.mark.parametrize(
+        ('w', 'ans'),
+        [(None, 280.75),
+         ([1000, 1019], 280.75),
+         ([1013, 1016], 116),
+         ([1012.8, 1016], 116),
+         ([1013.2, 1016], 116)])
+    def test_waverange(self, w, ans):
+        """Use given wavelength range on binned data."""
+        np.testing.assert_allclose(
+            self.obs.countrate(_area, waverange=w).value, ans)
+
+    def test_waverange_no_bin(self):
+        """Use given wavelength range on native dataset.
+
+        .. note:: Accuracy unsure as there was no precedent to test against.
+
+        """
+        w = [1000, 1019]
+        np.testing.assert_allclose(
+            self.obs.countrate(_area, waverange=w, binned=False).value, 271)
+
+    @pytest.mark.parametrize(
+        ('w', 'ans'),
+        [([1016, 1026], 140),
+         ([999, 1016], 172.75)])
+    def test_force(self, w, ans):
+        """Force calculation for partial overlap."""
+        np.testing.assert_allclose(
+            self.obs.countrate(_area, waverange=w, force=True).value, ans)
+
+        # Must raise error without force
+        with pytest.raises(exceptions.PartialOverlap):
+            self.obs.countrate(_area, waverange=w)
+
+    def test_disjoint_waverange(self):
+        with pytest.raises(exceptions.DisjointError):
+            self.obs.countrate(_area, waverange=[1020, 1030])
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+class TestCountRateNegFlux(object):
+    """Test countrate with files containing negative flux/throughput values."""
+    def setup_class(self):
+        self.bp = SpectralElement.from_file(get_pkg_data_filename(
+            os.path.join('data', 'cos_fuv_g130m_c1309_psa.fits')))
+        self.spfile = get_pkg_data_filename(os.path.join('data', 'us7.txt'))
+
+    @pytest.mark.parametrize(
+        ('keep_neg', 'ans'),
+        [(True, 1510.219531414891),
+         (False, 1627.8250215634343)])
+    def test_neg_handling(self, keep_neg, ans):
+        sp = SourceSpectrum.from_file(self.spfile, keep_neg=keep_neg)
+        obs = Observation(sp, self.bp)
+        c = obs.countrate(_area)
+        np.testing.assert_allclose(c.value, ans, rtol=1e-4)
+
+        if not keep_neg:
+            assert 'NegativeFlux' in obs.warnings
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_countrate_neg_leak():
+    """Test countrate of sub-sampling not exceeding total countrate.
+    https://github.com/spacetelescope/synphot_refactor/issues/126
+    """
+    # This bug only manifests itself in very specific cases.
+    bp = SpectralElement.from_file(get_pkg_data_filename(
+        os.path.join('data', 'stis_fuv_f25ndq2_mjd58300_0822774.fits')))
+    sp = SourceSpectrum.from_file(get_pkg_data_filename(
+        os.path.join('data', 'k93_4500_0_5_rn_box.fits')))
+    binset = np.fromfile(get_pkg_data_filename(
+        os.path.join('data', 'stis_fuv_f25ndq2_binset.bin')))
+    obs = Observation(sp, bp, binset=binset)
+    area = 45238.93416  # HST cm^2
+    wrange = [1109.22, 12000.0]  # Angstrom
+    c_all = obs.countrate(area)
+    c_sub = obs.countrate(area, waverange=wrange)
+    assert c_sub <= c_all
+
+
+def test_ccd_snr_calc():
+    """
+    A test to check that the math in observation.ccd_snr is done correctly.
+    Based on the worked example on pg. 56-57 of [1]_.
+
+    References
+    ----------
+    .. [1] Howell, S. B. 2000, *Handbook of CCD Astronomy* (Cambridge, UK:
+        Cambridge University Press)
+    """
+    t = 300 * u.s
+    readnoise = 5 * (u.ct / u.pixel)
+    darkcurrent = 22 * t * (u.ct / u.pixel / u.hr)
+    gain = 5 * (u.ct / u.adu)
+    background = 620 * (u.adu / u.pixel * gain)
+    n_background = 200 * u.pixel
+    npix = 1 * u.pixel
+    counts = 24013 * u.adu * gain
+
+    result = ccd_snr(counts, npix=npix, background=background,
+                     darkcurrent=darkcurrent, readnoise=readnoise,
+                     gain=gain, n_background=n_background)
+
+    # the value of the answer given in the text
+    answer = 342
+
+    # allow error to be +/- 1 for this test
+    assert_quantity_allclose(result, answer, atol=1)
+
+
+def test_snr_bright_object():
+    """
+    Test that observation.ccd_snr returns sqrt(counts), the expected value
+    for a bright target.
+    """
+    counts = 25e5 * u.ct
+    result = ccd_snr(counts)
+    answer = np.sqrt(counts.value)
+
+    assert_quantity_allclose(result, answer)
+
+
+def test_t_exp_numeric():
+    """
+    A test to check that the numerical method in
+    observation.exptime_from_ccd_snr (i.e. when the error in background
+    noise or gain is non-negligible) is done correctly. Based on the worked
+    example on pg. 56-57 of [1]_.
+
+    References
+    ----------
+    .. [1] Howell, S. B. 2000, *Handbook of CCD Astronomy* (Cambridge, UK:
+        Cambridge University Press)
+    """
+    t = 300 * u.s
+    snr = 342
+    gain = 5 * (u.ct / u.adu)
+    countrate = 24013 * u.adu * gain / t
+    npix = 1 * u.pixel
+    n_background = 200 * u.pixel
+    background_rate = 620 * (u.adu / u.pixel) * gain / t
+    darkcurrent_rate = 22 * (u.ct / u.pixel / u.hr)
+    readnoise = 5 * (u.ct / u.pixel)
+
+    result = exptime_from_ccd_snr(snr, countrate, npix=npix,
+                                  n_background=n_background,
+                                  background_rate=background_rate,
+                                  darkcurrent_rate=darkcurrent_rate,
+                                  readnoise=readnoise, gain=gain)
+
+    assert_quantity_allclose(result, t, atol=1 * u.s)
+
+
+def test_t_exp_analytic():
+    """
+    A test to check that the analytic method in
+    observation.exptime_from_ccd_snr is done correctly.
+    """
+    snr_set = 50
+    countrate = 1000 * (u.ct / u.s)
+    npix = 1 * u.pixel
+    background_rate = 100 * (u.ct / u.pixel / u.s)
+    darkcurrent_rate = 5 * (u.ct / u.pixel / u.s)
+    readnoise = 1 * (u.ct / u.pixel)
+
+    t = exptime_from_ccd_snr(snr_set, countrate, npix=npix,
+                             background_rate=background_rate,
+                             darkcurrent_rate=darkcurrent_rate,
+                             readnoise=readnoise)
+
+    # if t is correct, ccd_snr() should return snr_set:
+    snr_calc = ccd_snr(countrate * t,
+                       npix=npix,
+                       background=background_rate * t,
+                       darkcurrent=darkcurrent_rate * t,
+                       readnoise=readnoise)
+
+    assert_quantity_allclose(snr_calc, snr_set,
+                             atol=0.5 * u.Unit(""))
+
+
+def test_snr_with_countrate():
+    """
+    A test to make sure `ccd_snr` works with the units that
+    `countrate` returns.
+    """
+    area = 1 * u.m ** 2
+    bp = SpectralElement(Const1D)
+    source_spec = SourceSpectrum(BlackBodyNorm1D)
+    source_spec = source_spec.normalize(1 * u.ct, bp,
+                                        force='extrap',
+                                        wavelengths=source_spec.waveset,
+                                        area=area)
+    obs = Observation(source_spec, bp, force='extrap')
+    counts = obs.countrate(area) * u.s
+    snr = ccd_snr(counts)
+
+    assert_quantity_allclose(snr, 1 * u.Unit(""), rtol=1e-3)
+
+
+@raises(u.UnitsError)
+def test_counts_units():
+    """
+    A test to make sure ``ccd_snr`` raises a UnitError if the user
+    gives an incompatible unit for counts.
+    """
+    return ccd_snr(1 * u.m)
+
+
+@raises(u.UnitsError)
+def test_countrate_units():
+    """
+    A test to make sure ``exptime_from_ccd_snr`` raises a UnitError
+    if the user gives an incompatible countrate unit.
+    """
+    return exptime_from_ccd_snr(10, 1 * u.m)


### PR DESCRIPTION
The initial state of this PR is beyond a work in progress if you know what I mean 😅, but I wanted to put it out there so we can chat about it in our GSoC meeting.

So I'm envisioning some kind of wrapper for synphot in which you can initiate a class with the source spectrum of an object, give a telescope diameter, and boom, you can get attributes like SNR, countrate, exptime, etc...:
```
>>> from synphot.spectrum import SourceSpectrum
>>> from synphot.wrapper import Observe
>>> import astropy.units as u

>>> tele_diameter = 1 * u.m
>>> source_spec = SourceSpectrum(...)
>>> some_observation = Observe(source_spec, tele_diameter)

>>> some_observation.countrate
1e6 ct/s
>>> some_observation.snr
100
...
``` 
The observation can be customized by setting a bandpass, giving a desired SNR (to get an exposure time), providing the quantum efficiency of the CCD or an atmospheric transmission model, etc. 