### PR TITLE
add option for download_data to use the astropy cache

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@
   compatible with Python 3.6 or later and ``astropy`` 3.x or later. [#243]
 - Added support for ``RickerWavelet1D`` model that is the renamed version
   of ``MexicanHat1D`` model to be consistent with ``astropy`` 4.0. [#250]
+- Added option for ``synphot.utils.download_data()`` to download to the cache
+  instead of a specific location. [#211]
 
 0.2.1 (2019-12-20)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,8 @@
 - Added support for ``RickerWavelet1D`` model that is the renamed version
   of ``MexicanHat1D`` model to be consistent with ``astropy`` 4.0. [#250]
 - Added option for ``synphot.utils.download_data()`` to download to the cache
-  instead of a specific location. [#211]
+  instead of a specific location. Please note that new option is not fully
+  compatible with customization using ``synphot.cfg``. [#211]
 
 0.2.1 (2019-12-20)
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,9 +82,15 @@ via HTTP, create a local directory where you plan to store the data files
     >>> file_list = download_data('/my/local/dir/cdbs')  # doctest: +SKIP
 
 Then copy `synphot.cfg <https://github.com/spacetelescope/synphot_refactor/blob/master/synphot/synphot.cfg>`_
-to your ``$HOME/.astropy/config/`` directory, and replace every instance of
+to your ``$HOME/.astropy/config/`` directory, if it is not there already.
+Uncomment and replace every instance of
 ``/grp/hst/cdbs`` with ``/my/local/dir/cdbs`` so that ``synphot`` knows where to
 look for these files.
+
+On the contrary, if you wish to rely solely on Astropy caching mechanism,
+you can use ``download_data(None)``, but make sure that you do *not*
+modify your default ``$HOME/.astropy/config/synphot.cfg`` file. Otherwise,
+``synphot`` will try to use what is in ``synphot.cfg`` instead.
 
 .. note::
 

--- a/synphot/synphot.cfg
+++ b/synphot/synphot.cfg
@@ -1,31 +1,31 @@
 [config]
 
 ## Default integrator
-default_integrator = 'trapezoid'
+#default_integrator = 'trapezoid'
 
 ## Vega
-vega_file = /grp/hst/cdbs/calspec/alpha_lyr_stis_009.fits
+#vega_file = /grp/hst/cdbs/calspec/alpha_lyr_stis_009.fits
 
 ## Reddening/extinction laws
-lmc30dor_file = /grp/hst/cdbs/extinction/lmc_30dorshell_001.fits
-lmcavg_file = /grp/hst/cdbs/extinction/lmc_diffuse_001.fits
-mwavg_file = /grp/hst/cdbs/extinction/milkyway_diffuse_001.fits
-mwdense_file = /grp/hst/cdbs/extinction/milkyway_dense_001.fits
-mwrv21_file = /grp/hst/cdbs/extinction/milkyway_rv21_001.fits
-mwrv40_file = /grp/hst/cdbs/extinction/milkyway_rv4_001.fits
-smcbar_file = /grp/hst/cdbs/extinction/smc_bar_001.fits
-xgal_file = /grp/hst/cdbs/extinction/xgal_starburst_001.fits
+#lmc30dor_file = /grp/hst/cdbs/extinction/lmc_30dorshell_001.fits
+#lmcavg_file = /grp/hst/cdbs/extinction/lmc_diffuse_001.fits
+#mwavg_file = /grp/hst/cdbs/extinction/milkyway_diffuse_001.fits
+#mwdense_file = /grp/hst/cdbs/extinction/milkyway_dense_001.fits
+#mwrv21_file = /grp/hst/cdbs/extinction/milkyway_rv21_001.fits
+#mwrv40_file = /grp/hst/cdbs/extinction/milkyway_rv4_001.fits
+#smcbar_file = /grp/hst/cdbs/extinction/smc_bar_001.fits
+#xgal_file = /grp/hst/cdbs/extinction/xgal_starburst_001.fits
 
 ## Common filter bandpass
-bessel_h_file = /grp/hst/cdbs/comp/nonhst/bessell_h_004_syn.fits
-bessel_j_file = /grp/hst/cdbs/comp/nonhst/bessell_j_003_syn.fits
-bessel_k_file = /grp/hst/cdbs/comp/nonhst/bessell_k_003_syn.fits
-cousins_i_file = /grp/hst/cdbs/comp/nonhst/cousins_i_004_syn.fits
-cousins_r_file = /grp/hst/cdbs/comp/nonhst/cousins_r_004_syn.fits
-johnson_b_file = /grp/hst/cdbs/comp/nonhst/johnson_b_004_syn.fits
-johnson_i_file = /grp/hst/cdbs/comp/nonhst/johnson_i_003_syn.fits
-johnson_j_file = /grp/hst/cdbs/comp/nonhst/johnson_j_003_syn.fits
-johnson_k_file = /grp/hst/cdbs/comp/nonhst/johnson_k_003_syn.fits
-johnson_r_file = /grp/hst/cdbs/comp/nonhst/johnson_r_003_syn.fits
-johnson_u_file = /grp/hst/cdbs/comp/nonhst/johnson_u_004_syn.fits
-johnson_v_file = /grp/hst/cdbs/comp/nonhst/johnson_v_004_syn.fits
+#bessel_h_file = /grp/hst/cdbs/comp/nonhst/bessell_h_004_syn.fits
+#bessel_j_file = /grp/hst/cdbs/comp/nonhst/bessell_j_003_syn.fits
+#bessel_k_file = /grp/hst/cdbs/comp/nonhst/bessell_k_003_syn.fits
+#cousins_i_file = /grp/hst/cdbs/comp/nonhst/cousins_i_004_syn.fits
+#cousins_r_file = /grp/hst/cdbs/comp/nonhst/cousins_r_004_syn.fits
+#johnson_b_file = /grp/hst/cdbs/comp/nonhst/johnson_b_004_syn.fits
+#johnson_i_file = /grp/hst/cdbs/comp/nonhst/johnson_i_003_syn.fits
+#johnson_j_file = /grp/hst/cdbs/comp/nonhst/johnson_j_003_syn.fits
+#johnson_k_file = /grp/hst/cdbs/comp/nonhst/johnson_k_003_syn.fits
+#johnson_r_file = /grp/hst/cdbs/comp/nonhst/johnson_r_003_syn.fits
+#johnson_u_file = /grp/hst/cdbs/comp/nonhst/johnson_u_004_syn.fits
+#johnson_v_file = /grp/hst/cdbs/comp/nonhst/johnson_v_004_syn.fits

--- a/synphot/utils.py
+++ b/synphot/utils.py
@@ -252,14 +252,20 @@ def merge_wavelengths(waveset1, waveset2, threshold=1e-12):
     return out_wavelengths
 
 
-def download_data(cdbs_root, verbose=True, dry_run=False):
-    """Download CDBS data files to given root directory.
+def download_data(path_root=None, verbose=True, dry_run=False):
+    """Download synphot data files to given root directory or the astropy cache.
     Download is skipped if a data file already exists.
+
+    Note that if you have changed the path for the data files by providing a
+    synphot.cfg file pointing to local file, this function will not work. You
+    will need to have the configuration items point to wherever you wish to
+    download them from for this to work.
 
     Parameters
     ----------
-    cdbs_root : str
-        Root directory for CDBS data files.
+    path_root : str or None, optional
+        Root directory for data files. If None, download to the astropy cache
+        location instead of a specific directory.
 
     verbose : bool
         Print extra information to screen.
@@ -282,19 +288,23 @@ def download_data(cdbs_root, verbose=True, dry_run=False):
 
     """
     from .config import conf  # Avoid potential circular import
+    BASE_HOST = 'http://ssb.stsci.edu/cdbs/'
 
-    if not os.path.exists(cdbs_root):
-        os.makedirs(cdbs_root, exist_ok=True)
-        if verbose:  # pragma: no cover
-            print('Created {}'.format(cdbs_root))
-    elif not os.path.isdir(cdbs_root):
-        raise OSError('{} must be a directory'.format(cdbs_root))
+    if path_root is None:
+        usecache = True
+    else:
+        usecache = False
+        if not os.path.exists(path_root):
+            os.makedirs(path_root, exist_ok=True)
+            if verbose:  # pragma: no cover
+                print('Created {}'.format(path_root))
+        elif not os.path.isdir(path_root):
+            raise OSError('{} must be a directory'.format(path_root))
 
-    host = 'http://ssb.stsci.edu/cdbs/'
+        if not path_root.endswith(os.sep):
+            path_root += os.sep
+
     file_list = []
-
-    if not cdbs_root.endswith(os.sep):
-        cdbs_root += os.sep
 
     # See https://github.com/astropy/astropy/issues/8524
     for cfgitem in conf.__class__.__dict__.values():
@@ -304,33 +314,36 @@ def download_data(cdbs_root, verbose=True, dry_run=False):
 
         url = cfgitem()
 
-        if not url.startswith(host):
+        if not url.startswith(BASE_HOST):
             if verbose:  # pragma: no cover
                 print('{} is not from {}, skipping download'.format(
-                    url, host))
+                    url, BASE_HOST))
             continue
+        if not usecache:
+            dst = url.replace(BASE_HOST, path_root).replace('/', os.sep)
 
-        dst = url.replace(host, cdbs_root).replace('/', os.sep)
+            if os.path.exists(dst):
+                if verbose:  # pragma: no cover
+                    print('{} already exists, skipping download'.format(dst))
+                continue
 
-        if os.path.exists(dst):
-            if verbose:  # pragma: no cover
-                print('{} already exists, skipping download'.format(dst))
-            continue
-
-        # Create sub-directories, if needed.
-        subdirs = os.path.dirname(dst)
-        os.makedirs(subdirs, exist_ok=True)
+            # Create sub-directories, if needed.
+            subdirs = os.path.dirname(dst)
+            os.makedirs(subdirs, exist_ok=True)
 
         if not dry_run:  # pragma: no cover
             try:
-                src = download_file(url)
-                copyfile(src, dst)
+                src = download_file(url, cache=usecache)
+                if not usecache:
+                    copyfile(src, dst)
             except Exception as exc:
                 print('Download failed - {}'.format(str(exc)))
                 continue
-
-        file_list.append(dst)
+        if usecache:
+            file_list.append(src)
+        else:
+            file_list.append(dst)
         if verbose:  # pragma: no cover
-            print('{} downloaded to {}'.format(url, dst))
+            print('{} downloaded to {}'.format(url, file_list[-1]))
 
     return file_list


### PR DESCRIPTION
This PR closes #208 by making it possible to use the astropy download cache.  

One caveat: There are no unit tests.  I started trying to make one but then realized it's not clear to me that we can really test this properly without accidentally messing with the users' "true" cache.  The related tests in astropy test the cache machinery by downloading a "fake" file and then clearing just that file, but here we can't do it because we actually want the *correct* file.  So that's awkward. I can concoct some sort of complicated scheme like what we *used* to have in astropy where we fake the cache location, run the test, and then un-fake it, but that seems like it might be overkill for this.  @pllim do you agree and/or have a simpler idea for how I might test this?  Or alternatively I can add a quick test that would have the side-effect of potentially deleting the user's *actual* copy of the data (which is normally considered bad behavior for a test...)

(Note I did test it in the sense of actually running it myself... )

EDIT: Also fix #188 