### PR TITLE
MNT: Bump Vega data version

### DIFF
--- a/synphot/config.py
+++ b/synphot/config.py
@@ -23,7 +23,7 @@ class Conf(ConfigNamespace):
 
     # STANDARD STARS
     vega_file = ConfigItem(
-        'http://ssb.stsci.edu/cdbs/calspec/alpha_lyr_stis_008.fits', 'Vega')
+        'http://ssb.stsci.edu/cdbs/calspec/alpha_lyr_stis_009.fits', 'Vega')
 
     # REDDENING/EXTINCTION LAWS
     lmc30dor_file = ConfigItem(

--- a/synphot/synphot.cfg
+++ b/synphot/synphot.cfg
@@ -4,7 +4,7 @@
 default_integrator = 'trapezoid'
 
 ## Vega
-vega_file = /grp/hst/cdbs/calspec/alpha_lyr_stis_008.fits
+vega_file = /grp/hst/cdbs/calspec/alpha_lyr_stis_009.fits
 
 ## Reddening/extinction laws
 lmc30dor_file = /grp/hst/cdbs/extinction/lmc_30dorshell_001.fits

--- a/synphot/tests/test_observation.py
+++ b/synphot/tests/test_observation.py
@@ -342,7 +342,7 @@ class TestObsPar(object):
         vspec = SourceSpectrum.from_vega()
         np.testing.assert_allclose(
             self.obs.effstim(flux_unit=units.VEGAMAG, vegaspec=vspec).value,
-            ans)
+            ans, rtol=1e-4)
 
     @pytest.mark.parametrize('flux_unit', [u.mag, units.VEGAMAG])
     def test_effstim_exceptions(self, flux_unit):

--- a/synphot/tests/test_spectrum.py
+++ b/synphot/tests/test_spectrum.py
@@ -657,8 +657,8 @@ class TestNormalize(object):
             obs = Observation(rn_sp, self.acs, force='extrap')
         ct_rate = obs.countrate(_area)
 
-        # 0.1% agreement with IRAF SYNPHOT COUNTRATE
-        np.testing.assert_allclose(ct_rate.value, ans_countrate, rtol=1e-3)
+        # 0.2% agreement with IRAF SYNPHOT COUNTRATE
+        np.testing.assert_allclose(ct_rate.value, ans_countrate, rtol=2e-3)
 
     @pytest.mark.parametrize(
         ('sp_type', 'rn_val', 'ans_countrate'),

--- a/synphot/tests/test_utils.py
+++ b/synphot/tests/test_utils.py
@@ -152,7 +152,7 @@ def test_download_data(tmpdir):
 
     # Use case where user redefined data file to be non-STScI.
     filename = [fname for fname in file_list_1
-                if fname.endswith('alpha_lyr_stis_008.fits')][0]
+                if fname.endswith('alpha_lyr_stis_009.fits')][0]
     os.remove(filename)
     with conf.set_temp('vega_file', '/custom/host/my_vega.fits'):
         file_list_2 = utils.download_data(


### PR DESCRIPTION
I see that  `alpha_lyr_stis_009.fits` was made available in 2019-09-06.

@ibusko , is ETC using that one yet?