### PR TITLE
Compatibility with astropy blackbody refactoring

### DIFF
--- a/synphot/compat.py
+++ b/synphot/compat.py
@@ -4,7 +4,6 @@
 import astropy
 from astropy.utils.introspection import minversion
 
-__all__ = ['ASTROPY_LT_2_0', 'ASTROPY_LT_4_0']
+__all__ = ['ASTROPY_LT_4_0']
 
-ASTROPY_LT_2_0 = not minversion(astropy, '2.0')
 ASTROPY_LT_4_0 = not minversion(astropy, '4.0')

--- a/synphot/models.py
+++ b/synphot/models.py
@@ -254,7 +254,7 @@ class BlackBodyNorm1D(BlackBody1D):
 
     def evaluate(self, x, temperature, *args):
         """Evaluate the model."""
-        bbflux = super(BlackBodyNorm1D, self).evaluate(*args)
+        bbflux = super(BlackBodyNorm1D, self).evaluate(x, temperature, *args)
         y = bbflux * self._omega
 
         # If the temperature parameter has no unit, we should return a

--- a/synphot/spectrum.py
+++ b/synphot/spectrum.py
@@ -39,7 +39,7 @@ class BaseSpectrum(object):
 
     .. note::
 
-        Until `astropy.modeling` can handle units, all parameters
+        For backward compatibility, all parameters
         are converted to pre-defined internal units.
 
     Parameters
@@ -98,6 +98,8 @@ class BaseSpectrum(object):
             'alpha': u.dimensionless_unscaled,
             'beta': u.dimensionless_unscaled},
         'Lorentz1D': {'amplitude': 'flux', 'x_0': 'wave', 'fwhm': 'wave'},
+        'RickerWavelet1D': {
+            'amplitude': 'flux', 'x_0': 'wave', 'sigma': 'wave'},
         'MexicanHat1D': {'amplitude': 'flux', 'x_0': 'wave', 'sigma': 'wave'},
         'PowerLaw1D': {
             'amplitude': 'flux', 'x_0': 'wave',
@@ -120,6 +122,7 @@ class BaseSpectrum(object):
         'GaussianFlux1D': 'mean',
         'LogParabola1D': 'x_0',
         'Lorentz1D': 'x_0',
+        'RickerWavelet1D': 'x_0',
         'MexicanHat1D': 'x_0',
         'PowerLaw1D': 'x_0',
         'Trapezoid1D': 'x_0'}

--- a/synphot/tests/test_spectrum.py
+++ b/synphot/tests/test_spectrum.py
@@ -42,7 +42,6 @@ else:
     HAS_SCIPY = True
 
 HAS_SCIPY = HAS_SCIPY and minversion(scipy, '0.14')
-ASTROPY_LT_20 = not minversion(astropy, '2.0')
 
 # GLOBAL VARIABLES
 _vspec = None  # Loaded in test_load_vspec()
@@ -50,23 +49,28 @@ _vspec = None  # Loaded in test_load_vspec()
 
 def setup_module(module):
     # https://github.com/astropy/astropy/issues/6383
-    if not ASTROPY_LT_20:
-        import astropy.constants as const
-        from astropy.constants import si, astropyconst13
+    import astropy.constants as const
+    from astropy.constants import si, astropyconst13
 
-        const.sigma_sb = si.sigma_sb = astropyconst13.sigma_sb
-        const.h = si.h = astropyconst13.h
-        const.k_B = si.k_B = astropyconst13.k_B
+    const.sigma_sb = si.sigma_sb = astropyconst13.sigma_sb
+    const.h = si.h = astropyconst13.h
+    const.k_B = si.k_B = astropyconst13.k_B
 
 
 def teardown_module(module):
     # https://github.com/astropy/astropy/issues/6383
-    if not ASTROPY_LT_20:
-        import astropy.constants as const
-        from astropy.constants import si, astropyconst20
+    import astropy.constants as const
+    from astropy.constants import si
+    if ASTROPY_LT_4_0:
+        from astropy.constants import astropyconst20
         const.sigma_sb = si.sigma_sb = astropyconst20.sigma_sb
         const.h = si.h = astropyconst20.h
         const.k_B = si.k_B = astropyconst20.k_B
+    else:
+        from astropy.constants import astropyconst40
+        const.sigma_sb = si.sigma_sb = astropyconst40.sigma_sb
+        const.h = si.h = astropyconst40.h
+        const.k_B = si.k_B = astropyconst40.k_B
 
 
 @pytest.mark.remote_data

--- a/synphot/tests/test_thermal.py
+++ b/synphot/tests/test_thermal.py
@@ -9,7 +9,6 @@ import numpy as np
 import pytest
 
 # ASTROPY
-import astropy
 from astropy import units as u
 from astropy.utils import minversion
 from astropy.utils.data import get_pkg_data_filename
@@ -17,6 +16,7 @@ from astropy.utils.data import get_pkg_data_filename
 # LOCAL
 from .. import exceptions
 from ..thermal import ThermalSpectralElement
+from ..utils import ASTROPY_LT_4_0
 
 try:
     import scipy
@@ -26,28 +26,32 @@ else:
     HAS_SCIPY = True
 
 HAS_SCIPY = HAS_SCIPY and minversion(scipy, '0.14')
-ASTROPY_LT_20 = not minversion(astropy, '2.0')
 
 
 def setup_module(module):
     # https://github.com/astropy/astropy/issues/6383
-    if not ASTROPY_LT_20:
-        import astropy.constants as const
-        from astropy.constants import si, astropyconst13
+    import astropy.constants as const
+    from astropy.constants import si, astropyconst13
 
-        const.sigma_sb = si.sigma_sb = astropyconst13.sigma_sb
-        const.h = si.h = astropyconst13.h
-        const.k_B = si.k_B = astropyconst13.k_B
+    const.sigma_sb = si.sigma_sb = astropyconst13.sigma_sb
+    const.h = si.h = astropyconst13.h
+    const.k_B = si.k_B = astropyconst13.k_B
 
 
 def teardown_module(module):
     # https://github.com/astropy/astropy/issues/6383
-    if not ASTROPY_LT_20:
-        import astropy.constants as const
-        from astropy.constants import si, astropyconst20
+    import astropy.constants as const
+    from astropy.constants import si
+    if ASTROPY_LT_4_0:
+        from astropy.constants import astropyconst20
         const.sigma_sb = si.sigma_sb = astropyconst20.sigma_sb
         const.h = si.h = astropyconst20.h
         const.k_B = si.k_B = astropyconst20.k_B
+    else:
+        from astropy.constants import astropyconst40
+        const.sigma_sb = si.sigma_sb = astropyconst40.sigma_sb
+        const.h = si.h = astropyconst40.h
+        const.k_B = si.k_B = astropyconst40.k_B
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/synphot/utils.py
+++ b/synphot/utils.py
@@ -56,7 +56,7 @@ def validate_totalflux(totalflux):
 
     Parameters
     ----------
-    totalflux : float
+    totalflux : float or `~astropy.units.quantity.Quantity`
         Integrated flux.
 
     Raises
@@ -205,7 +205,7 @@ def generate_wavelengths(minwave=500, maxwave=26000, num=10000, delta=None,
     return waveset.astype(np.float64) * wave_unit, waveset_str
 
 
-def merge_wavelengths(waveset1, waveset2, threshold=1e-12):
+def merge_wavelengths(waveset1, waveset2, threshold=(1e-12 * u.AA)):
     """Return the union of the two sets of wavelengths using
     :func:`numpy.union1d`.
 
@@ -222,10 +222,10 @@ def merge_wavelengths(waveset1, waveset2, threshold=1e-12):
         Wavelength values, assumed to be in the same unit already.
         Also see :func:`~synphot.models.get_waveset`.
 
-    threshold : float, optional
+    threshold : `~astropy.units.quantity.Quantity`, optional
         Merged wavelength values are considered "too close together"
         when the difference is smaller than this number.
-        The default is 1e-12.
+        The default is 1e-12 Angstrom.
 
     Returns
     -------


### PR DESCRIPTION
**TODO**

- [ ] Clean up unit support for models and spectra. Minversion of astropy now support units in modeling.
- [x] Wait for astropy/astropy#9282 to be merged.
- [x] Remove hack to test against upstream PR branch.
- [x] Undo `filterwarnings` added in #229 -- Done in #250 
- [x] Add test from #223 -- Done in #250 
- [ ] Deprecate `MexicanHat1D` like astropy/astropy#9445 -- See #249 
- [ ] Add change logs.
