### PR TITLE
ENH: Integrate with dust-extinction API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@
   compatible with Python 3.6 or later and ``astropy`` 3.x or later. [#243]
 - Added support for ``RickerWavelet1D`` model that is the renamed version
   of ``MexicanHat1D`` model to be consistent with ``astropy`` 4.0. [#250]
+- Added support for extinction curve from ``dust-extinction``. [#251]
 - Added option for ``synphot.utils.download_data()`` to download to the cache
   instead of a specific location. Please note that new option is not fully
   compatible with customization using ``synphot.cfg``. [#211]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,7 +128,8 @@ man_pages = [('index', project.lower(), project + u' Documentation',
 intersphinx_mapping.update({
     'astropy': ('https://docs.astropy.org/en/latest/', None),
     'stsynphot': ('https://stsynphot.readthedocs.io/en/latest/', None),
-    'specutils': ('https://specutils.readthedocs.io/en/latest/', None)})
+    'specutils': ('https://specutils.readthedocs.io/en/latest/', None),
+    'dust-extinction': ('https://dust-extinction.readthedocs.io/en/latest/', None)})
 
 # -- Options for linkcheck output ---------------------------------------------
 linkcheck_retry = 5

--- a/docs/synphot/spectrum.rst
+++ b/docs/synphot/spectrum.rst
@@ -104,7 +104,8 @@ de-reddens the spectrum), and then multiply it to the source::
 .. |xg_ext_ref| replace:: :ref:`Calzetti et al. (2000) <synphot-ref-extinction-calzetti2000>`
 
 For extinction due to Lyman-alpha forest, see :ref:`tutorial_lyman_alpha`
-tutorial.
+tutorial. To use a model from the ``dust-extinction`` package, see
+:ref:`tutorial_dust_extinction`.
 
 You can **redshift** a source spectrum in several ways (shown in example
 below), either by setting its ``z`` attribute or passing in a ``z`` keyword

--- a/docs/synphot/spectrum.rst
+++ b/docs/synphot/spectrum.rst
@@ -104,7 +104,8 @@ de-reddens the spectrum), and then multiply it to the source::
 .. |xg_ext_ref| replace:: :ref:`Calzetti et al. (2000) <synphot-ref-extinction-calzetti2000>`
 
 For extinction due to Lyman-alpha forest, see :ref:`tutorial_lyman_alpha`
-tutorial. To use a model from the ``dust-extinction`` package, see
+tutorial. To use a model from the
+:ref:`dust-extinction <dust-extinction:dust-extinction-mainpage>` package, see
 :ref:`tutorial_dust_extinction`.
 
 You can **redshift** a source spectrum in several ways (shown in example

--- a/docs/synphot/tutorials.rst
+++ b/docs/synphot/tutorials.rst
@@ -104,7 +104,8 @@ Using dust-extinction model
 ---------------------------
 
 In this tutorial, you will learn how to apply an extinction curve using a
-model from the ``dust-extinction`` package:
+model from the
+:ref:`dust-extinction <dust-extinction:dust-extinction-mainpage>` package:
 
 .. doctest-requires:: dust-extinction
 

--- a/docs/synphot/tutorials.rst
+++ b/docs/synphot/tutorials.rst
@@ -98,6 +98,34 @@ continuum-normalized spectrum.
     plt.axhline(1, ls='--', color='k')
 
 
+.. _tutorial_dust_extinction:
+
+Using dust-extinction model
+---------------------------
+
+In this tutorial, you will learn how to apply an extinction curve using a
+model from the ``dust-extinction`` package:
+
+.. doctest-requires:: dust-extinction
+
+    >>> import numpy as np
+    >>> from astropy import units as u
+    >>> from dust_extinction.parameter_averages import CCM89
+    >>> from synphot import SourceSpectrum, ReddeningLaw
+    >>> from synphot.models import BlackBodyNorm1D
+    >>> ccm89_model = CCM89(Rv=3.1)
+    >>> wav = np.arange(0.1, 3, 0.001) * u.micron
+    >>> ebv = 0.1  # E(B-V)
+    >>> redlaw = ReddeningLaw(ccm89_model)
+    >>> extcurve = redlaw.extinction_curve(ebv, wavelengths=wav)
+    >>> bb = SourceSpectrum(BlackBodyNorm1D, temperature=5000 * u.K)
+    >>> bb.integrate()  # doctest: +FLOAT_CMP
+    <Quantity 9.31004974 ph / (cm2 s)>
+    >>> sp = bb * extcurve
+    >>> sp.integrate()  # doctest: +FLOAT_CMP
+    <Quantity 8.27106961 ph / (cm2 s)>
+
+
 .. _tutorial_fit_ew:
 
 Fitting, Equivalent Width

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ xfail_strict = true
 filterwarnings =
     ignore:can't resolve package from __spec__
     ignore:numpy.ufunc size changed:RuntimeWarning
+    ignore:Class CCM89 defines class attributes
 
 [metadata]
 name = synphot

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ python_requires = >=3.6
 [options.extras_require]
 all =
     specutils>=0.7
+    dust-extinction
 test =
     pytest-astropy
 docs =

--- a/synphot/compat.py
+++ b/synphot/compat.py
@@ -11,6 +11,14 @@ except ImportError:
 else:
     HAS_SPECUTILS = True
 
-__all__ = ['ASTROPY_LT_4_0', 'HAS_SPECUTILS']
+try:
+    import dust_extinction  # noqa
+except ImportError:
+    HAS_DUST_EXTINCTION = False
+else:
+    HAS_DUST_EXTINCTION = True
+
+
+__all__ = ['ASTROPY_LT_4_0', 'HAS_SPECUTILS', 'HAS_DUST_EXTINCTION']
 
 ASTROPY_LT_4_0 = not minversion(astropy, '4.0')

--- a/synphot/models.py
+++ b/synphot/models.py
@@ -388,8 +388,14 @@ class Empirical1D(Tabular1D):
         # Assume NaN at both ends need to be extrapolated based on
         # nearest end point.
         if self.fill_value is np.nan:
-            # Cannot use sampleset() due to ExtinctionModel1D
+            # Cannot use sampleset() due to ExtinctionModel1D.
             x = np.squeeze(self.points)
+
+            # np.squeeze may throw unit away.
+            if (isinstance(self.points, tuple) and
+                    isinstance(self.points[0], u.Quantity) and
+                    not isinstance(x, u.Quantity)):
+                x = x * self.points[0].unit
 
             if np.isscalar(y):  # pragma: no cover
                 if inputs < x[0]:

--- a/synphot/reddening.py
+++ b/synphot/reddening.py
@@ -81,7 +81,7 @@ class ReddeningLaw(BaseUnitlessSpectrum):
         # Duck-typing dust-extinction package API.
         if HAS_DUST_EXTINCTION and hasattr(self.model, 'extinguish'):
             y = self.model.extinguish(x, self.model.Rv * ebv)
-            header['ReddeningLaw'] = '{}'.format(self.model)
+            header['ReddeningLaw'] = '{!r}'.format(self.model)
         else:
             y = 10 ** (-0.4 * self(x).value * ebv)
             header['ReddeningLaw'] = self.meta.get('expr', 'unknown')

--- a/synphot/reddening.py
+++ b/synphot/reddening.py
@@ -80,7 +80,7 @@ class ReddeningLaw(BaseUnitlessSpectrum):
 
         # Duck-typing dust-extinction package API.
         if HAS_DUST_EXTINCTION and hasattr(self.model, 'extinguish'):
-            y = self.model.extinguish(x, self.model.Rv * ebv)
+            y = self.model.extinguish(x, Ebv=ebv)
             header['ReddeningLaw'] = '{!r}'.format(self.model)
         else:
             y = 10 ** (-0.4 * self(x).value * ebv)

--- a/synphot/tests/test_reddening.py
+++ b/synphot/tests/test_reddening.py
@@ -81,6 +81,7 @@ class TestExtinction(object):
         extcurve = redlaw.extinction_curve(ebv, wavelengths=wav)
 
         assert_quantity_allclose(extcurve(wav), ans)
+        assert extcurve.meta['header']['ReddeningLaw'] == '<CCM89(Rv=3.1)>'
 
     def test_mul_spec(self):
         """Apply extinction curve in inverse micron to flat spectrum in


### PR DESCRIPTION
Fix #132 

p.s. Sorry, Karl, no `__mul__` magic needed after all. 😉 

**TODO**

- [x] Address review comments.
- [x] Use Intersphinx to link to `dust-extinction` doc once karllark/dust_extinction#144 is merged and deployed.
- [ ] Open issue over at `astropy-tutorials` as a reminder to update Color Excess tutorial with this API in the future.