### PR TITLE
MNT: Update default Vega

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 0.3.1 (unreleased)
 ==================
 
+- Default Vega is now ``alpha_lyr_stis_010.fits``. [#266]
 
 0.3.0 (2020-03-17)
 ==================

--- a/synphot/config.py
+++ b/synphot/config.py
@@ -22,7 +22,7 @@ class Conf(ConfigNamespace):
 
     # STANDARD STARS
     vega_file = ConfigItem(
-        'http://ssb.stsci.edu/cdbs/calspec/alpha_lyr_stis_009.fits', 'Vega')
+        'http://ssb.stsci.edu/cdbs/calspec/alpha_lyr_stis_010.fits', 'Vega')
 
     # REDDENING/EXTINCTION LAWS
     lmc30dor_file = ConfigItem(

--- a/synphot/synphot.cfg
+++ b/synphot/synphot.cfg
@@ -4,7 +4,7 @@
 #default_integrator = 'trapezoid'
 
 ## Vega
-#vega_file = /grp/hst/cdbs/calspec/alpha_lyr_stis_009.fits
+#vega_file = /grp/hst/cdbs/calspec/alpha_lyr_stis_010.fits
 
 ## Reddening/extinction laws
 #lmc30dor_file = /grp/hst/cdbs/extinction/lmc_30dorshell_001.fits

--- a/synphot/tests/test_observation.py
+++ b/synphot/tests/test_observation.py
@@ -330,7 +330,7 @@ class TestObsPar:
         vspec = SourceSpectrum.from_vega()
         np.testing.assert_allclose(
             self.obs.effstim(flux_unit=units.VEGAMAG, vegaspec=vspec).value,
-            ans, rtol=1e-4)
+            ans, rtol=0.001)
 
     @pytest.mark.parametrize('flux_unit', [u.mag, units.VEGAMAG])
     def test_effstim_exceptions(self, flux_unit):

--- a/synphot/tests/test_spectrum_source.py
+++ b/synphot/tests/test_spectrum_source.py
@@ -419,9 +419,9 @@ class TestNormalize:
             obs = Observation(rn_sp, self.acs, force='extrap')
         ct_rate = obs.countrate(_area)
 
-        # 0.2% agreement with IRAF SYNPHOT COUNTRATE
+        # 0.7% agreement with IRAF SYNPHOT COUNTRATE
         assert_quantity_allclose(
-            ct_rate, ans_countrate * (u.ct / u.s), rtol=2e-3)
+            ct_rate, ans_countrate * (u.ct / u.s), rtol=0.007)
 
     @pytest.mark.parametrize(
         ('sp_type', 'rn_val', 'ans_countrate'),

--- a/synphot/tests/test_utils.py
+++ b/synphot/tests/test_utils.py
@@ -158,7 +158,7 @@ def test_download_data(tmpdir):
     # Use case where user redefined data file to be non-STScI.
     # While the given file will be used, default Vega is downloaded anyway.
     filename = [fname for fname in file_list_1
-                if fname.endswith('alpha_lyr_stis_009.fits')][0]
+                if fname.endswith('alpha_lyr_stis_010.fits')][0]
     os.remove(filename)
     with conf.set_temp('vega_file', '/custom/host/my_vega.fits'):
         file_list_2 = utils.download_data(


### PR DESCRIPTION
Fix #258 . This makes `synphot` in-sync with what is advertised at https://archive.stsci.edu/hlsps/reference-atlases/cdbs/current_calspec/ as of May 2020.

**TODO**

- [x] Need approval from HST ETC.
- [x] Need approval from JWST ETC.
- [ ] Do I have to update PySynphot too?