### PR TITLE
Update build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = ["setuptools>=30.3.0",
             "setuptools_scm",
-            "wheel",
             "oldest-supported-numpy",
             "extension-helpers"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Currently the wheel and ~~numpy~~ packages are not required to build
synphot. Probably this is a remnant from the astropy-helpers era.