### PR TITLE
add a target for the CI badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,7 @@ synphot
     :alt: Documentation Status
 
 .. image:: https://github.com/spacetelescope/synphot_refactor/workflows/CI/badge.svg
+    :target: https://github.com/spacetelescope/synphot_refactor/actions?query=workflow%3ACI
     :alt: Github Actions CI Status
 
 .. image:: https://codecov.io/gh/spacetelescope/synphot_refactor/branch/master/graph/badge.svg


### PR DESCRIPTION
Very minor edit - I noticed the readme CI badge doesn't have a target, which means if you click on it you get just the badge.  I *think* this is now the right target.