### PR TITLE
Use absolute imports in unit tests

### DIFF
--- a/synphot/tests/test_binning.py
+++ b/synphot/tests/test_binning.py
@@ -13,8 +13,8 @@ from astropy import units as u
 from astropy.utils.data import get_pkg_data_filename
 
 # LOCAL
-from .. import binning, exceptions, specio
-from ..utils import merge_wavelengths, generate_wavelengths
+from synphot import binning, exceptions, specio
+from synphot.utils import merge_wavelengths, generate_wavelengths
 
 
 @pytest.mark.parametrize(
@@ -196,7 +196,8 @@ class TestCalcbinflux:
         # Get bandpass data for interpolation.
         hdr, wave, thru = specio.read_fits_spec(
             get_pkg_data_filename(
-                os.path.join('data', 'hst_acs_hrc_f555w.fits')),
+                os.path.join('data', 'hst_acs_hrc_f555w.fits'),
+                package='synphot.tests'),
             flux_col='THROUGHPUT', flux_unit=u.dimensionless_unscaled)
 
         # Binned data.
@@ -232,7 +233,7 @@ class TestCalcbinflux:
 
     def test_c_ext(self):
         # C-EXT: Sum over each bin.
-        from .. import synphot_utils
+        from synphot import synphot_utils
 
         binflux_c, intwave_c = synphot_utils.calcbinflux(
             self.size, self.i_beg, self.i_end, self.avflux, self.deltaw)

--- a/synphot/tests/test_blackbody.py
+++ b/synphot/tests/test_blackbody.py
@@ -4,8 +4,8 @@ import numpy as np
 from astropy import constants as const
 from astropy import units as u
 
-from ..blackbody import blackbody_nu
-from ..units import FNU
+from synphot.blackbody import blackbody_nu
+from synphot.units import FNU
 
 
 # This test was removed from astropy in

--- a/synphot/tests/test_integrator.py
+++ b/synphot/tests/test_integrator.py
@@ -23,9 +23,9 @@ from astropy.tests.helper import assert_quantity_allclose
 from numpy.testing import assert_allclose
 
 # LOCAL
-from .. import models, units
-from ..exceptions import SynphotError
-from ..spectrum import SourceSpectrum, SpectralElement
+from synphot import models, units
+from synphot.exceptions import SynphotError
+from synphot.spectrum import SourceSpectrum, SpectralElement
 
 
 class TestSourceConstFlux1D:

--- a/synphot/tests/test_models.py
+++ b/synphot/tests/test_models.py
@@ -25,9 +25,9 @@ from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
 
 # LOCAL
-from .. import specio, units
-from ..models import (BlackBody1D, ConstFlux1D, Empirical1D, PowerLawFlux1D,
-                      get_metadata)
+from synphot import specio, units
+from synphot.models import (BlackBody1D, ConstFlux1D, Empirical1D,
+                            PowerLawFlux1D, get_metadata)
 
 
 def setup_module(module):
@@ -123,7 +123,8 @@ class TestEmpirical1D:
     """Test Empirical1D model."""
     def setup_class(self):
         filename = get_pkg_data_filename(
-            os.path.join('data', 'hst_acs_hrc_f555w_x_grw70d5824.fits'))
+            os.path.join('data', 'hst_acs_hrc_f555w_x_grw70d5824.fits'),
+            package='synphot.tests')
         hdr, x, f = specio.read_spec(filename)
         y = units.convert_flux(x, f, units.PHOTLAM)
         self.flux_flam = f.value

--- a/synphot/tests/test_observation.py
+++ b/synphot/tests/test_observation.py
@@ -18,19 +18,24 @@ from astropy.utils.exceptions import (AstropyDeprecationWarning,
                                       AstropyUserWarning)
 
 # LOCAL
-from .test_units import _area
-from .. import exceptions, units
-from ..compat import HAS_SPECUTILS  # noqa
-from ..models import (BlackBodyNorm1D, Box1D, ConstFlux1D, Empirical1D,
-                      GaussianFlux1D)
-from ..observation import Observation
-from ..spectrum import SourceSpectrum, SpectralElement
+from synphot.tests.test_units import _area
+from synphot import exceptions, units
+from synphot.compat import HAS_SPECUTILS  # noqa
+from synphot.models import (
+    BlackBodyNorm1D, Box1D, ConstFlux1D, Empirical1D, GaussianFlux1D
+)
+from synphot.observation import Observation
+from synphot.spectrum import SourceSpectrum, SpectralElement
 
 # Global test data files
 _specfile = get_pkg_data_filename(
-    os.path.join('data', 'grw_70d5824_stisnic_005.fits'))
+    os.path.join('data', 'grw_70d5824_stisnic_005.fits'),
+    package='synphot.tests'
+)
 _bandfile = get_pkg_data_filename(
-    os.path.join('data', 'hst_acs_hrc_f555w.fits'))
+    os.path.join('data', 'hst_acs_hrc_f555w.fits'),
+    package='synphot.tests'
+)
 
 
 class TestObservation:
@@ -412,8 +417,11 @@ class TestCountRateNegFlux:
     """Test countrate with files containing negative flux/throughput values."""
     def setup_class(self):
         self.bp = SpectralElement.from_file(get_pkg_data_filename(
-            os.path.join('data', 'cos_fuv_g130m_c1309_psa.fits')))
-        self.spfile = get_pkg_data_filename(os.path.join('data', 'us7.txt'))
+            os.path.join('data', 'cos_fuv_g130m_c1309_psa.fits'),
+            package='synphot.tests'))
+        self.spfile = get_pkg_data_filename(
+            os.path.join('data', 'us7.txt'), package='synphot.tests'
+        )
 
     @pytest.mark.parametrize(
         ('keep_neg', 'ans'),
@@ -439,11 +447,14 @@ def test_countrate_neg_leak():
     """
     # This bug only manifests itself in very specific cases.
     bp = SpectralElement.from_file(get_pkg_data_filename(
-        os.path.join('data', 'stis_fuv_f25ndq2_mjd58300_0822774.fits')))
+        os.path.join('data', 'stis_fuv_f25ndq2_mjd58300_0822774.fits'),
+        package='synphot.tests'))
     sp = SourceSpectrum.from_file(get_pkg_data_filename(
-        os.path.join('data', 'k93_4500_0_5_rn_box.fits')))
+        os.path.join('data', 'k93_4500_0_5_rn_box.fits'),
+        package='synphot.tests'))
     binset = np.fromfile(get_pkg_data_filename(
-        os.path.join('data', 'stis_fuv_f25ndq2_binset.bin')))
+        os.path.join('data', 'stis_fuv_f25ndq2_binset.bin'),
+        package='synphot.tests'))
     obs = Observation(sp, bp, binset=binset)
     area = 45238.93416  # HST cm^2
     wrange = [1109.22, 12000.0]  # Angstrom

--- a/synphot/tests/test_reddening.py
+++ b/synphot/tests/test_reddening.py
@@ -19,19 +19,20 @@ from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
 
 # LOCAL
-from .. import exceptions, units
-from ..compat import HAS_DUST_EXTINCTION  # noqa
-from ..models import ConstFlux1D, Empirical1D
-from ..observation import Observation
-from ..reddening import ReddeningLaw, etau_madau
-from ..spectrum import SourceSpectrum, SpectralElement
+from synphot import exceptions, units
+from synphot.compat import HAS_DUST_EXTINCTION  # noqa
+from synphot.models import ConstFlux1D, Empirical1D
+from synphot.observation import Observation
+from synphot.reddening import ReddeningLaw, etau_madau
+from synphot.spectrum import SourceSpectrum, SpectralElement
 
 
 class TestExtinction:
     """Test ReddeningLaw and ExtinctionCurve classes (most methods)."""
     def setup_class(self):
         rfile = get_pkg_data_filename(
-            os.path.join('data', 'milkyway_diffuse_001.fits'))
+            os.path.join('data', 'milkyway_diffuse_001.fits'),
+            package='synphot.tests')
         self.redlaw = ReddeningLaw.from_file(rfile)
         self.extcurve = self.redlaw.extinction_curve(0.3 * u.mag)
 
@@ -90,9 +91,11 @@ class TestExtinction:
         https://github.com/spacetelescope/synphot_refactor/issues/129
         """
         bp = SpectralElement.from_file(get_pkg_data_filename(
-            os.path.join('data', 'hst_acs_hrc_f850lp.fits')))
+            os.path.join('data', 'hst_acs_hrc_f850lp.fits'),
+            package='synphot.tests'))
         qso = SourceSpectrum.from_file(get_pkg_data_filename(
-            os.path.join('data', 'qso_template_001.dat')))
+            os.path.join('data', 'qso_template_001.dat'),
+            package='synphot.tests'))
         extcurve = self.redlaw.extinction_curve(1.0 * u.mag)
         spext = qso * extcurve
         with pytest.warns(AstropyUserWarning):

--- a/synphot/tests/test_specio.py
+++ b/synphot/tests/test_specio.py
@@ -18,7 +18,7 @@ from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
 
 # LOCAL
-from .. import exceptions, specio, units
+from synphot import exceptions, specio, units
 
 
 @pytest.mark.remote_data
@@ -28,7 +28,7 @@ def test_read_remote_spec():
     .. note:: This is just I/O test. No check on data quality.
 
     """
-    from .. import config
+    from synphot import config
 
     hdr, wave, flux = specio.read_remote_spec(
         config.conf.vega_file, cache=False, show_progress=False)
@@ -41,7 +41,7 @@ def test_read_remote_spec():
 def test_read_ascii_spec():
     """Test read local ASCII spectrum."""
     specfile = get_pkg_data_filename(
-        os.path.join('data', 'qso_template_001.dat'))
+        os.path.join('data', 'qso_template_001.dat'), package='synphot.tests')
     hdr, wave, flux = specio.read_spec(specfile)
 
     assert_quantity_allclose(wave[::500], [800, 2050, 3300, 4550, 5800] * u.AA)

--- a/synphot/tests/test_spectrum_bandpass.py
+++ b/synphot/tests/test_spectrum_bandpass.py
@@ -16,11 +16,11 @@ from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
 
 # LOCAL
-from .test_units import _area, _wave, _flux_photlam
-from .. import exceptions, units
-from ..compat import HAS_SPECUTILS  # noqa
-from ..models import Box1D, Empirical1D, GaussianAbsorption1D
-from ..spectrum import SpectralElement
+from synphot.tests.test_units import _area, _wave, _flux_photlam
+from synphot import exceptions, units
+from synphot.compat import HAS_SPECUTILS  # noqa
+from synphot.models import Box1D, Empirical1D, GaussianAbsorption1D
+from synphot.spectrum import SpectralElement
 
 
 @pytest.mark.remote_data
@@ -52,7 +52,8 @@ class TestEmpiricalBandpassFromFile:
     """This is the most common model used in ASTROLIB PYSYNPHOT."""
     def setup_class(self):
         bandfile = get_pkg_data_filename(
-            os.path.join('data', 'hst_acs_hrc_f555w.fits'))
+            os.path.join('data', 'hst_acs_hrc_f555w.fits'),
+            package='synphot.tests')
         self.bp = SpectralElement.from_file(bandfile)
 
     def test_invalid_flux_unit(self):

--- a/synphot/tests/test_spectrum_misc.py
+++ b/synphot/tests/test_spectrum_misc.py
@@ -18,11 +18,11 @@ from astropy.modeling.models import Const1D, RedshiftScaleFactor
 from astropy.tests.helper import assert_quantity_allclose
 
 # LOCAL
-from .test_units import _wave, _flux_jy, _flux_photlam
-from .. import exceptions, units
-from ..compat import ASTROPY_LT_4_0
-from ..models import Box1D, Empirical1D, GaussianFlux1D, get_waveset
-from ..spectrum import SourceSpectrum, SpectralElement
+from synphot.tests.test_units import _wave, _flux_jy, _flux_photlam
+from synphot import exceptions, units
+from synphot.compat import ASTROPY_LT_4_0
+from synphot.models import Box1D, Empirical1D, GaussianFlux1D, get_waveset
+from synphot.spectrum import SourceSpectrum, SpectralElement
 
 
 def setup_module(module):

--- a/synphot/tests/test_spectrum_source.py
+++ b/synphot/tests/test_spectrum_source.py
@@ -21,15 +21,17 @@ from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
 
 # LOCAL
-from .test_units import _area, _wave, _flux_jy, _flux_photlam, _flux_vegamag
-from .. import exceptions, units
-from ..compat import ASTROPY_LT_4_0
-from ..compat import HAS_SPECUTILS  # noqa
-from ..models import (
+from synphot.tests.test_units import (
+    _area, _wave, _flux_jy, _flux_photlam, _flux_vegamag
+)
+from synphot import exceptions, units
+from synphot.compat import ASTROPY_LT_4_0
+from synphot.compat import HAS_SPECUTILS  # noqa
+from synphot.models import (
     BlackBodyNorm1D, Box1D, ConstFlux1D, Empirical1D, Gaussian1D,
     GaussianFlux1D, Lorentz1D, RickerWavelet1D, PowerLawFlux1D)
-from ..observation import Observation
-from ..spectrum import SourceSpectrum, SpectralElement
+from synphot.observation import Observation
+from synphot.spectrum import SourceSpectrum, SpectralElement
 
 # GLOBAL VARIABLES
 _vspec = None  # Loaded in test_load_vspec()
@@ -92,7 +94,8 @@ class TestEmpiricalSourceFromFile:
     """This is the most common model used in ASTROLIB PYSYNPHOT."""
     def setup_class(self):
         specfile = get_pkg_data_filename(
-            os.path.join('data', 'hst_acs_hrc_f555w_x_grw70d5824.fits'))
+            os.path.join('data', 'hst_acs_hrc_f555w_x_grw70d5824.fits'),
+            package='synphot.tests')
         self.sp = SourceSpectrum.from_file(specfile)
 
     def test_invalid_flux_unit(self):
@@ -394,7 +397,8 @@ class TestNormalize:
 
         # ACS bandpass: band(acs,hrc,f555w)
         bandfile = get_pkg_data_filename(
-            os.path.join('data', 'hst_acs_hrc_f555w.fits'))
+            os.path.join('data', 'hst_acs_hrc_f555w.fits'),
+            package='synphot.tests')
         self.acs = SpectralElement.from_file(bandfile)
 
         # Box bandpass: box(5500,1)

--- a/synphot/tests/test_thermal.py
+++ b/synphot/tests/test_thermal.py
@@ -13,8 +13,8 @@ from astropy import units as u
 from astropy.utils.data import get_pkg_data_filename
 
 # LOCAL
-from .. import exceptions
-from ..thermal import ThermalSpectralElement
+from synphot import exceptions
+from synphot.thermal import ThermalSpectralElement
 
 
 def setup_module(module):
@@ -39,7 +39,8 @@ class TestThermalSpectralElement:
     """Test ``ThermalSpectralElement``."""
     def setup_class(self):
         thfile = get_pkg_data_filename(
-            os.path.join('data', 'wfc3_ir_g141_src_003_th.fits'))
+            os.path.join('data', 'wfc3_ir_g141_src_003_th.fits'),
+            package='synphot.tests')
         self.th = ThermalSpectralElement.from_file(thfile)
 
     def test_taper(self):
@@ -66,6 +67,7 @@ class TestThermalSpectralElement:
 
         # Missing DEFT keyword
         thfile = get_pkg_data_filename(
-            os.path.join('data', 'hst_acs_hrc_f555w.fits'))
+            os.path.join('data', 'hst_acs_hrc_f555w.fits'),
+            package='synphot.tests')
         with pytest.raises(exceptions.SynphotError):
             ThermalSpectralElement.from_file(thfile, flux_col='THROUGHPUT')

--- a/synphot/tests/test_units.py
+++ b/synphot/tests/test_units.py
@@ -15,7 +15,7 @@ import pytest
 from astropy import units as u
 
 # LOCAL
-from .. import exceptions, units
+from synphot import exceptions, units
 
 # Wavelength conversions
 _wave_angstrom = [0.1, 5000.0, 10000.0] * u.AA

--- a/synphot/tests/test_utils.py
+++ b/synphot/tests/test_utils.py
@@ -12,7 +12,7 @@ import pytest
 from astropy import units as u
 
 # LOCAL
-from .. import exceptions, utils, units
+from synphot import exceptions, utils, units
 
 
 @pytest.mark.parametrize(
@@ -131,7 +131,7 @@ def test_download_bad_root(tmpdir):
 
 def test_download_data(tmpdir):
     """Test data download helper in dry run mode."""
-    from ..config import conf
+    from synphot.config import conf
 
     # Use case where user downloads all data into new dir.
     cdbs_root = os.path.join(tmpdir.strpath, 'cdbs')


### PR DESCRIPTION
This PR contains only those changes from https://github.com/spacetelescope/synphot_refactor/pull/310 that pertain to switching unit tests from relative to absolute imports.

The changes to `tox.ini` will be addressed in https://github.com/spacetelescope/synphot_refactor/pull/310