### PR TITLE
TST: Fix outdated catch_warnings usage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,8 +8,10 @@ text_file_format = rst
 addopts = --doctest-rst --doctest-ignore-import-errors
 xfail_strict = true
 filterwarnings =
+    error
     ignore:can't resolve package from __spec__
-    ignore:numpy.ufunc size changed:RuntimeWarning
+    ignore:numpy\.ndarray size changed:RuntimeWarning
+    ignore:numpy\.ufunc size changed:RuntimeWarning
     ignore:Class CCM89 defines class attributes
 
 [metadata]

--- a/synphot/tests/test_observation.py
+++ b/synphot/tests/test_observation.py
@@ -12,7 +12,7 @@ import pytest
 # ASTROPY
 from astropy import units as u
 from astropy.modeling.models import Const1D
-from astropy.tests.helper import catch_warnings, assert_quantity_allclose
+from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import (AstropyDeprecationWarning,
                                       AstropyUserWarning)
@@ -254,10 +254,10 @@ class TestObsPar:
 
     @pytest.mark.parametrize('binned', [True, False])
     def test_efflam(self, binned):
-        with catch_warnings(AstropyDeprecationWarning) as w:
+        with pytest.warns(AstropyDeprecationWarning,
+                          match='Usage of EFFLPHOT is deprecated') as w:
             x = self.obs.effective_wavelength(mode='efflphot', binned=binned)
-            assert len(w) == 1
-            assert str(w[0].message) == 'Usage of EFFLPHOT is deprecated.'
+        assert len(w) == 1
 
         np.testing.assert_allclose(x.value, 5344.312, rtol=1e-4)
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/synphot_refactor/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

The outdated usage was throwing an extra warning about `distutils` locally and was failing the test unnecessarily.