### PR TITLE
DOC: Clarify TUNITn handling

### DIFF
--- a/docs/synphot/overview.rst
+++ b/docs/synphot/overview.rst
@@ -392,12 +392,17 @@ throughput (for bandpass). The extension header must contain the following
 keywords (unless you overwrite them with non-default values in
 :func:`~synphot.specio.read_fits_spec`):
 
-* ``TUNIT1`` set to :ref:`supported wavelength unit name <synphot_units>`.
-* ``TUNIT2`` set to :ref:`supported flux unit name <synphot_units>`
-  (source spectrum only).
 * ``TTYPE1`` set to "WAVELENGTH".
 * ``TTYPE2`` set to "FLUX" (for source spectrum) or "THROUGHPUT"
   (for bandpass).
+
+While these were required in ASTROLIB PYSYNPHOT, they are optional here in that
+default units would be applied, where applicable, if they are missing from
+the header. Regardless, setting them is highly recommended:
+
+* ``TUNIT1`` set to :ref:`supported wavelength unit name <synphot_units>`.
+* ``TUNIT2`` set to :ref:`supported flux unit name <synphot_units>`
+  (source spectrum only).
 
 For writing out FITS table, many options can be set to non-default as
 acceptable by :func:`~synphot.specio.write_fits_spec`.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/synphot_refactor/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description

Problem: `acs_f814w_wfc_008_syn.fits` does not have `TUNIT1` (and `TUNIT2`) defined. PySynphot threw a `KeyError` but `synphot` could load it fine.

Cause: PySynphot only grabs unit from `TUNIT1` in header and panics if it is not there. Meanwhile, `synphot` grabs it if it is there, but if it is not there, it assigns a default value, which you can overwrite with function keyword.

https://github.com/spacetelescope/synphot_refactor/blob/7cd3e888c40b2fdb6555f9c864378629ece3103e/synphot/specio.py#L147-L154

But why: I really don't remember why Past Self ™️ made that design choice. My best guess is I wanted the handling of ASCII and FITS parser to be more consistent.

Propose fix here: Clarify in the documentation where backward-compatibility is not really happening.