### PR TITLE
DOC: Clarify that countrate cannot handle NaNs

### DIFF
--- a/docs/synphot/observation.rst
+++ b/docs/synphot/observation.rst
@@ -107,6 +107,8 @@ one wavelength bin corresponds to one detector pixel::
     >>> obs.countrate(area)  # doctest: +FLOAT_CMP
     <Quantity 137190.19332899 ct / s>
 
+.. note:: If flux values contain NaNs, ``countrate()`` will raise ``SynphotError``.
+
 An observation can be converted to a **regular source spectrum** containing
 only the wavelength set and sampled flux (binned by default) by using its
 :meth:`~synphot.observation.Observation.as_spectrum` method.

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -558,7 +558,7 @@ class Observation(BaseSourceSpectrum):
             Wavelength range only partially overlaps with observation.
 
         synphot.exceptions.SynphotError
-            Calculation failed.
+            Calculation failed, including but not limited to NaNs in flux.
 
         """
         # Sample the observation


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/synphot_refactor/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request is to clarify the limitation of countrate method.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes spacetelescope/stsynphot_refactor#151

Relevant pages in rendered doc:

* https://synphot--319.org.readthedocs.build/en/319/synphot/observation.html
* https://synphot--319.org.readthedocs.build/en/319/api/synphot.observation.Observation.html#synphot.observation.Observation.countrate