### PR TITLE
Separate VEGAMAG and OBMAG

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 - Dropped support for Python 3.6 and 3.7. Minimum supported Python
   version is now 3.8. [#330]
 
+- OBMAG and VEGAMAG are no longer interchangeable. [#331]
+
 1.1.1 (2021-11-18)
 ==================
 

--- a/docs/synphot/spectrum.rst
+++ b/docs/synphot/spectrum.rst
@@ -48,7 +48,7 @@ for flux conversion)::
     <Quantity [6.62607015e-24, 6.62607015e-23] FNU>
     >>> area = 45238.93416 * units.AREA  # HST
     >>> sp(wave, flux_unit=units.OBMAG, area=area)  # doctest: +FLOAT_CMP
-    <Quantity [-21.52438718,-21.52438718] OBMAG>
+    <Magnitude [-21.52438718,-21.52438718] mag(OB)>
 
 .. _synphot_reddening:
 

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -458,7 +458,7 @@ class Observation(BaseSourceSpectrum):
         if flux_unit == u.count or flux_unit_name == units.OBMAG.to_string():
             val = self.countrate(area, binned=False, wavelengths=wavelengths)
 
-            if flux_unit.decompose() == u.mag:
+            if flux_unit == units.OBMAG:
                 eff_stim = (-2.5 * np.log10(val.value)) * flux_unit
             else:
                 eff_stim = val

--- a/synphot/tests/test_units.py
+++ b/synphot/tests/test_units.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Test units.py module.
 
-.. note:: VEGAMAG conversion is tested in test_spectrum.py.
+.. note:: VEGAMAG conversion is tested in test_spectrum_source.py.
 
 .. note:: spectral_density_integrated is tested in astropy>=4.1.
 
@@ -13,6 +13,7 @@ import pytest
 
 # ASTROPY
 from astropy import units as u
+from astropy.tests.helper import assert_quantity_allclose
 
 # LOCAL
 from synphot import exceptions, units
@@ -176,3 +177,18 @@ def test_flux_conversion_exceptions():
         units.convert_flux(_wave, _flux_photlam, u.count, area=None)
     with pytest.raises(exceptions.SynphotError):
         units.convert_flux(_wave, _flux_obmag, units.PHOTLAM, area=None)
+
+
+def test_vegamag_obmag_calculations():
+    assert_quantity_allclose(
+        5 * units.VEGAMAG - 2.5 * units.VEGAMAG, u.Magnitude(2.5))
+    assert_quantity_allclose(
+        (5 * units.VEGAMAG - 2.5 * units.VEGAMAG).to(u.one), 0.1)
+
+    # Should not be interchangeable with astropy mag unit or with another
+    # custom mag unit, but error is only raised if .to(u.one) is called.
+    msg = 'subtract magnitudes so the unit got lost'
+    with pytest.raises(u.UnitConversionError, match=msg):
+        (5 * units.VEGAMAG - 2.5 * u.STmag).to(u.one)
+    with pytest.raises(u.UnitConversionError, match=msg):
+        5 * units.VEGAMAG - 2.5 * units.OBMAG.to(u.one)

--- a/synphot/units.py
+++ b/synphot/units.py
@@ -49,10 +49,10 @@ FLAM = u.def_unit(
 FNU = u.def_unit(
     'fnu', u.erg / (u.cm**2 * u.s * u.Hz),
     format={'generic': 'FNU', 'console': 'FNU'})
-OBMAG = u.def_unit(
-    'obmag', u.mag, format={'generic': 'OBMAG', 'console': 'OBMAG'})
-VEGAMAG = u.def_unit(
-    'vegamag', u.mag, format={'generic': 'VEGAMAG', 'console': 'VEGAMAG'})
+_u_ob = u.def_unit('OB')
+OBMAG = u.mag(_u_ob)
+_u_vega = u.def_unit('VEGA')
+VEGAMAG = u.mag(_u_vega)
 
 # Register with astropy units
 u.add_enabled_units([PHOTLAM, PHOTNU, FLAM, FNU, OBMAG, VEGAMAG])
@@ -348,6 +348,10 @@ def validate_unit(input_unit):
             output_unit = u.STmag
         elif input_unit_lowcase in ('abmag', 'mag(ab)'):
             output_unit = u.ABmag
+        elif input_unit_lowcase in ('obmag', 'mag(ob)'):
+            output_unit = OBMAG
+        elif input_unit_lowcase in ('vegamag', 'mag(vega)'):
+            output_unit = VEGAMAG
 
         else:
             try:  # astropy.units is case-sensitive

--- a/synphot/units.py
+++ b/synphot/units.py
@@ -1,9 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """This module handles photometry units that are not in `astropy.units`."""
 
-# THIRD-PARTY
-import numpy as np
-
 # ASTROPY
 from astropy import constants as const
 from astropy import units as u
@@ -109,20 +106,12 @@ def spectral_density_vega(wav, vegaflux):
         PHOTLAM, equivalencies=u.spectral_density(wav)).value
 
     def converter(x):
-        """Set nan/inf to -99 mag."""
-        val = -2.5 * np.log10(x / vega_photlam)
-        result = np.zeros(val.shape, dtype=np.float64) - 99
-        mask = np.isfinite(val)
-        if result.ndim > 0:
-            result[mask] = val[mask]
-        elif mask:
-            result = np.asarray(val)
-        return result
+        return x / vega_photlam
 
     def iconverter(x):
-        return vega_photlam * 10**(-0.4 * x)
+        return x * vega_photlam
 
-    return [(PHOTLAM, VEGAMAG, converter, iconverter)]
+    return [(PHOTLAM, VEGAMAG.physical_unit, converter, iconverter)]
 
 
 def spectral_density_count(wav, area):
@@ -156,14 +145,8 @@ def spectral_density_count(wav, area):
     def iconverter_count(x):
         return x / factor
 
-    def converter_obmag(x):
-        return -2.5 * np.log10(x * factor)
-
-    def iconverter_obmag(x):
-        return 10**(-0.4 * x) / factor
-
     return [(PHOTLAM, u.count, converter_count, iconverter_count),
-            (PHOTLAM, OBMAG, converter_obmag, iconverter_obmag)]
+            (PHOTLAM, OBMAG.physical_unit, converter_count, iconverter_count)]
 
 
 def convert_flux(wavelengths, fluxes, out_flux_unit, **kwargs):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/synphot_refactor/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request is to fix #327 

*This is breaking change!* Unit string will change from, say, `'VEGAMAG'` to `'mag(VEGA)'`. Also the behavior also changes because it is now a magnitude object, not just "plain Quantity."

### TODO

- [x] Make tests pass.
- [x] Test `stsynphot` against this PR branch. See spacetelescope/stsynphot_refactor#162
- [x] Need blessing from ETC. cc @vglaidler @ariedel @cdsontag 
  - Contacted them on 2022-05-17
  - Response from Adric: *I tried it on some of our regression tests that use vegamags and abmags (we have none that use OBmags). Our multimission/normalization and jwst/workbooks test suites all passed without complaint. Pandeia is compatible with your change... I think the PR is OK to merge. It passes all the relevant tests.* (2022-05-23)

### Blocked by (SOLVED)

<details>

@mhvk , I am trying to follow your advice at https://github.com/astropy/astropy/pull/13158#discussion_r858962549 but I am unable to get the new magnitude definitions to work with existing unit conversion equivalencies. What am I missing?

https://github.com/spacetelescope/synphot_refactor/blob/bd229608b8a2977ca1fad9cf2a2d5abb4bfcae80/synphot/units.py#L244-L245

https://github.com/spacetelescope/synphot_refactor/blob/bd229608b8a2977ca1fad9cf2a2d5abb4bfcae80/synphot/units.py#L291-L293

https://github.com/spacetelescope/synphot_refactor/blob/bd229608b8a2977ca1fad9cf2a2d5abb4bfcae80/synphot/units.py#L128

```
.../synphot/units.py in _convert_flux(wavelengths, fluxes, out_flux_unit, area, vegaspec)
    289             area = area * AREA
    290
--> 291         out_flux = fluxes.to(
    292             out_flux_unit,
    293             equivalencies=spectral_density_count(wavelengths, area))

.../astropy/units/quantity.py in to(self, unit, equivalencies, copy)
    844             # Avoid using to_value to ensure that we make a copy. We also
    845             # don't want to slow down this method (esp. the scalar case).
--> 846             value = self._to_value(unit, equivalencies)
    847         else:
    848             # to_value only copies if necessary

.../astropy/units/quantity.py in _to_value(self, unit, equivalencies)
    798         if not self.dtype.names or isinstance(self.unit, StructuredUnit):
    799             # Standard path, let unit to do work.
--> 800             return self.unit.to(unit, self.view(np.ndarray),
    801                                 equivalencies=equivalencies)
    802

.../astropy/units/function/core.py in to(self, other, value, equivalencies)
    255             try:
    256                 # when other is not a function unit
--> 257                 return self.physical_unit.to(other, self.to_physical(value),
    258                                              equivalencies)
    259             except UnitConversionError as e:

.../astropy/units/core.py in to(self, other, value, equivalencies)
   1128             return UNITY
   1129         else:
-> 1130             return self._get_converter(Unit(other),
   1131                                        equivalencies=equivalencies)(value)
   1132

.../astropy/units/core.py in _get_converter(self, other, equivalencies)
   1044         # if that doesn't work, maybe we can do it with equivalencies?
   1045         try:
-> 1046             return self._apply_equivalencies(
   1047                 self, other, self._normalize_equivalencies(equivalencies))
   1048         except UnitsError as exc:

.../astropy/units/core.py in _apply_equivalencies(self, unit, other, equivalencies)
   1002                     pass
   1003                 try:
-> 1004                     scale1 = tunit._to(unit)
   1005                     scale2 = funit._to(other)
   1006                     return make_converter(scale1, b, scale2)

AttributeError: 'MagUnit' object has no attribute '_to'
```

</details>