### PR TITLE
Enforce little endian when reading Numpy test data file

### DIFF
--- a/synphot/tests/test_observation.py
+++ b/synphot/tests/test_observation.py
@@ -454,7 +454,7 @@ def test_countrate_neg_leak():
         package='synphot.tests'))
     binset = np.fromfile(get_pkg_data_filename(
         os.path.join('data', 'stis_fuv_f25ndq2_binset.bin'),
-        package='synphot.tests'))
+        package='synphot.tests'), dtype='<f8')
     obs = Observation(sp, bp, binset=binset)
     area = 45238.93416  # HST cm^2
     wrange = [1109.22, 12000.0]  # Angstrom


### PR DESCRIPTION
Numpy data (written with `ndarray.tofile()` are usually system dependent; at least they depend on the byte order. This makes the `test_countrate_neg_leak()` [fail on big endian platforms (IBM zSystems/s390x)](https://buildd.debian.org/status/fetch.php?pkg=synphot&arch=s390x&ver=1.1.1-2&stamp=1658536121&raw=0). This patch enforces little endian on all platforms with `np.fromfile()` so the test passes there as well. With this patch, [the package passes on s390x](https://buildd.debian.org/status/fetch.php?pkg=synphot&arch=s390x&ver=1.1.1-3&stamp=1658641250&raw=0).