### PR TITLE
Remove AstroConda installation instructions

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,11 +53,7 @@ packages:
 
 You can install **synphot** using one of the following ways:
 
-* From `AstroConda <https://astroconda.readthedocs.io/en/latest/>`_::
-
-    conda install synphot -c http://ssb.stsci.edu/astroconda
-
-* From ``conda-forge`` channel::
+* From the ``conda-forge`` channel::
 
     conda install synphot -c conda-forge
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/synphot_refactor/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

I noticed that the docs ask for Python >=3.8 while AstroConda is only compatible with Python <=3.7. As such, the installation option that uses the AstroConda channel doesn't work.

If you like this change, I can propose the same one for `stsynphot`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
