### PR TITLE
Modifying Box1D model to allow step input 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,10 @@
 
 - OBMAG and VEGAMAG are no longer interchangeable. [#331]
 
+- ``Box1D`` model now takes optional ``step`` input to allow user control
+  over the generate sampleset. Default behavior maintains backwards 
+  compatibility. [#340]
+
 1.1.1 (2021-11-18)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@
 
 - ``Box1D`` model now takes optional ``step`` input to allow user control
   over the generated sampleset. Default behavior maintains backwards 
-  compatibility. [#340]
+  compatibility. [#342]
 
 1.1.1 (2021-11-18)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@
 - OBMAG and VEGAMAG are no longer interchangeable. [#331]
 
 - ``Box1D`` model now takes optional ``step`` input to allow user control
-  over the generate sampleset. Default behavior maintains backwards 
+  over the generated sampleset. Default behavior maintains backwards 
   compatibility. [#340]
 
 1.1.1 (2021-11-18)

--- a/synphot/models.py
+++ b/synphot/models.py
@@ -192,10 +192,14 @@ class Box1D(_models.Box1D):
         (nominally Angstrom). Defaults to 0.01
 
     """
-    def __init__(self, step=0.01, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
+
+        if "step" in kwargs:
+            self.step = kwargs.pop("step")
+        else:
+            self.step = 0.01
 
         super(Box1D, self).__init__(*args, **kwargs)
-        self.step = float(step)
 
     @staticmethod
     def _calc_sampleset(w1, w2, step, minimal):

--- a/synphot/models.py
+++ b/synphot/models.py
@@ -185,7 +185,18 @@ class Box1D(_models.Box1D):
     """Same as `astropy.modeling.functional_models.Box1D`, except with
     ``sampleset`` defined.
 
+    Parameters
+    ----------
+    step : float
+        Distance of first and last points w.r.t. bounding box. In default units
+        (nominally Angstrom). Defaults to 0.01
+
     """
+    def __init__(self, step=0.01, *args, **kwargs):
+
+        super(Box1D, self).__init__(*args, **kwargs)
+        self.step = float(step)
+
     @staticmethod
     def _calc_sampleset(w1, w2, step, minimal):
         """Calculate sampleset for each model."""
@@ -196,19 +207,23 @@ class Box1D(_models.Box1D):
 
         return arr
 
-    def sampleset(self, step=0.01, minimal=False):
+    def sampleset(self, step=None, minimal=False):
         """Return ``x`` array that samples the feature.
 
         Parameters
         ----------
-        step : float
-            Distance of first and last points w.r.t. bounding box.
+        step : float, optional
+            Distance of first and last points w.r.t. bounding box. If None,
+            set to attribute ``step``.
 
         minimal : bool
             Only return the minimal points needed to define the box;
             i.e., box edges and a point outside on each side.
 
         """
+        if step is None:
+            step = self.step
+
         if ASTROPY_LT_5_0:
             w1, w2 = self.bounding_box
         else:

--- a/synphot/tests/test_spectrum_misc.py
+++ b/synphot/tests/test_spectrum_misc.py
@@ -152,20 +152,18 @@ class TestWaveset:
         np.testing.assert_array_equal(bp2.waveset.value, w_true)
         np.testing.assert_array_equal(bp3.waveset.value, w_true)
 
-    def test_box1d_coarse_step(self):
-        bp = SpectralElement(Box1D, x_0=2000, width=1, step=0.1)
-        w = bp.waveset.value
-        w_true = bp.model.sampleset()
+    def test_box1d_set_step(self):
+        # first test that setting step to default value produces the same
+        # waveset as it did before step was a valid input
+        bp1 = SpectralElement(Box1D, x_0=2000, width=1)
+        assert bp1.waveset.shape == (103,)
 
-        np.testing.assert_array_equal(w, w_true)
-        np.testing.assert_allclose(
-            w[([0, 1, -2, -1], )], bp.model.sampleset(minimal=True))
+        bp2 = SpectralElement(Box1D, x_0=2000, width=1, step=0.01)
+        np.testing.assert_array_equal(bp1.waveset.value, bp2.waveset.value)
 
-        # Make sure scale does not change waveset
-        bp2 = bp * 2
-        bp3 = 0.5 * bp
-        np.testing.assert_array_equal(bp2.waveset.value, w_true)
-        np.testing.assert_array_equal(bp3.waveset.value, w_true)
+        # next test that setting a coarser step produces a smaller waveset
+        bp3 = SpectralElement(Box1D, x_0=2000, width=1, step=0.2)
+        assert bp3.waveset.size < bp1.waveset.size
 
     def test_composite_none(self):
         bp1 = SpectralElement(Box1D, amplitude=1, x_0=5000, width=10)

--- a/synphot/tests/test_spectrum_misc.py
+++ b/synphot/tests/test_spectrum_misc.py
@@ -152,6 +152,21 @@ class TestWaveset:
         np.testing.assert_array_equal(bp2.waveset.value, w_true)
         np.testing.assert_array_equal(bp3.waveset.value, w_true)
 
+    def test_box1d_coarse_step(self):
+        bp = SpectralElement(Box1D, x_0=2000, width=1, step=0.1)
+        w = bp.waveset.value
+        w_true = bp.model.sampleset()
+
+        np.testing.assert_array_equal(w, w_true)
+        np.testing.assert_allclose(
+            w[([0, 1, -2, -1], )], bp.model.sampleset(minimal=True))
+
+        # Make sure scale does not change waveset
+        bp2 = bp * 2
+        bp3 = 0.5 * bp
+        np.testing.assert_array_equal(bp2.waveset.value, w_true)
+        np.testing.assert_array_equal(bp3.waveset.value, w_true)
+
     def test_composite_none(self):
         bp1 = SpectralElement(Box1D, amplitude=1, x_0=5000, width=10)
         bp2 = SpectralElement(Const1D, amplitude=2)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/synphot_refactor/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request is to address #340. Adds step input to Box1D model while preserving prior behavior as default and adds covering unit test. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #340
