### PR TITLE
Add OSX ARM64 wheel

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -27,15 +27,15 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install pip "twine>=3.3" -U
-        python -m pip install "cibuildwheel==2.11.2"
-    # TODO: Enable py310-* when scipy allows
     - name: Build wheels
-      run: python -m cibuildwheel --output-dir wheelhouse
+      uses: pypa/cibuildwheel@v2.12.1
       env:
         CIBW_BUILD: 'cp38-* cp39-* cp310-* cp311-*'
         CIBW_SKIP: '*-musllinux_*'
         CIBW_ARCHS_LINUX: 'x86_64'
         CIBW_ARCHS_WINDOWS: 'AMD64'
+        CIBW_ARCHS_MACOS: 'arm64'
+        CIBW_TEST_SKIP: '*-macosx_arm64'
         CIBW_TEST_REQUIRES: 'pytest pytest-astropy'
         CIBW_TEST_COMMAND: 'python -c "import synphot; synphot.test()"'
     - name: Check wheels

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,14 @@
-1.2.0 (unreleased)
+1.2.0 (2023-03-20)
 ==================
 
 - New ``filter_parameterization`` subpackage to handle filter parameterization,
   adapted from ``tynt`` package written by Brett Morris. [#257]
+
+- OBMAG and VEGAMAG are no longer interchangeable. [#331]
+
+- ``Box1D`` model now takes optional ``step`` input to allow user control
+  over the generated sampleset. Default behavior maintains backwards 
+  compatibility. [#342]
 
 - Dropped support for Python 3.6 and 3.7. Minimum supported Python
   version is now 3.8. [#330]
@@ -10,11 +16,7 @@
 - Bumped minimum supported versions for ``numpy`` to 1.18,
   ``astropy`` to 4.3, and ``scipy`` to 1.3. [#341]
 
-- OBMAG and VEGAMAG are no longer interchangeable. [#331]
-
-- ``Box1D`` model now takes optional ``step`` input to allow user control
-  over the generated sampleset. Default behavior maintains backwards 
-  compatibility. [#342]
+- Added wheel for OSX ARM64 architecture. [#352]
 
 1.1.1 (2021-11-18)
 ==================


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/synphot_refactor/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request is to add OSX ARM64 wheel to the release process. I decided not to switch to OpenAstronomy workflow. I already have something that works and I don't see much value right now to switch to something I cannot control.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #351
