### PR TITLE
refactor toxenvs and use OpenAstronomy workflows

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 jobs:
-  initial_check:
+  validate:
     name: Mandatory checks before CI
     runs-on: ubuntu-latest
     steps:
@@ -35,84 +35,38 @@ jobs:
 
   # The rest only run if above are done
 
+  check:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    needs: [ validate ]
+    with:
+      envs: |
+        - linux: check-style
+        - linux: check-security
+        - linux: check-docs
+        - linux: build-dist
+
   tests:
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
-    needs: initial_check
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-
-          - name: Code style checks
-            os: ubuntu-latest
-            python: 3.x
-            toxenv: codestyle
-
-          - name: PEP 517 build
-            os: ubuntu-latest
-            python: 3.x
-            toxenv: twine
-
-          - name: Security audit
-            os: ubuntu-latest
-            python: 3.x
-            toxenv: bandit
-
-          - name: Link check
-            os: ubuntu-latest
-            python: 3.x
-            toxenv: linkcheck
-
-          - name: Test without optional deps
-            os: ubuntu-latest
-            python: 3.9
-            toxenv: py39-test
-
-          - name: Coverage test with remote data
-            os: ubuntu-latest
-            python: '3.10'
-            toxenv: py310-test-alldeps-cov
-            toxposargs: --remote-data
-
-          - name: Test with dev dependencies
-            os: ubuntu-latest
-            python: '3.11'
-            toxenv: py311-test-devdeps
-
-          - name: Test with old dependencies
-            os: ubuntu-20.04
-            python: 3.8
-            toxenv: py38-test-oldestdeps
-
-          - name: Test in OSX
-            os: macos-latest
-            python: '3.10'
-            toxenv: py310-test-alldeps
-
-          # NOTE: If TRDS cannot take the hit, disable --remote-data
-          - name: Test in Windows with remote data
-            os: windows-latest
-            python: 3.9
-            toxenv: py39-test-alldeps
-            toxposargs: --remote-data
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python }}
-    - name: Install Python dependencies
-      run: |
-        python -m pip install --upgrade pip tox
-    - name: Run tests
-      run: tox -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
-    - name: Upload coverage to codecov
-      if: ${{ contains(matrix.toxenv,'-cov') }}
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage.xml
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    needs: [ validate ]
+    with:
+      envs: |
+        - linux: test-oldestdeps-xdist-cov
+          python-version: 3.8
+        - linux: test-xdist
+          python-version: 3.8
+        - linux: test-xdist
+          python-version: 3.9
+        # NOTE: If TRDS cannot take the hit, disable --remote-data
+        - windows: test-alldeps-xdist
+          python-version: 3.9
+          posargs: --remote-data
+        - linux: test-xdist
+          python-version: 3.10
+        - linux: test-xdist
+          python-version: 3.11
+        - macos: test-xdist
+          python-version: 3.11
+        - linux: test-devdeps-xdist
+        - linux: test-alldeps-xdist-cov
+          posargs: --remote-data
+          coverage: codecov

--- a/.github/workflows/predeps_workflow.yml
+++ b/.github/workflows/predeps_workflow.yml
@@ -12,40 +12,14 @@ permissions:
 
 jobs:
   tests:
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-
-          - name: RC test on Linux with remote data
-            os: ubuntu-latest
-            python: '3.11'
-            toxenv: py311-test-predeps
-            toxposargs: --remote-data
-
-          - name: RC test on OSX
-            os: macos-latest
-            python: '3.10'
-            toxenv: py310-test-predeps
-
-          - name: RC test on Windows
-            os: windows-latest
-            python: 3.9
-            toxenv: py39-test-predeps
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python }}
-    - name: Install Python dependencies
-      run: |
-        python -m pip install --upgrade pip tox
-    - name: Run tests
-      run: tox -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    needs: [ validate ]
+    with:
+      envs: |
+        - windows: test-predeps-xdist
+          python-version: 3.9
+        - macos: test-predeps-xdist
+          python-version: 3.10
+        - linux: test-predeps-xdist
+          python-version: 3.11
+          posargs: --remote-data

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ pass_env =
 
 # Run the tests in a temporary directory to make sure that we don't import
 # package from the source tree
-change_dir = .tmp/{env_name}
+# change_dir = .tmp/{env_name}
 
 # tox environments are constructued with so-called 'factors' (or terms)
 # separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,8 @@
 [tox]
 envlist =
-    py{38,39,310,311}-test{,-alldeps,-oldestdeps,-devdeps,-predeps}{,-cov}
-    codestyle
-    twine
-    bandit
-    linkcheck
+    check-{style,security,docs}
+    py{38,39,310,311}-test{,-alldeps,-oldestdeps,-devdeps,-predeps}{,-cov}-xdist
+    build-dist
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
@@ -12,11 +10,15 @@ requires =
 [testenv]
 
 # Pass through the following environemnt variables which are needed for the CI
-passenv = HOME,WINDIR,CC,CI
+pass_env = 
+    HOME
+    WINDIR
+    CC
+    CI
 
 # Run the tests in a temporary directory to make sure that we don't import
 # package from the source tree
-changedir = .tmp/{envname}
+change_dir = .tmp/{env_name}
 
 # tox environments are constructued with so-called 'factors' (or terms)
 # separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:
@@ -32,45 +34,65 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-
+    xdist: using parallel processing
 deps =
 
     # The oldestdeps factor is intended to be used to install the oldest versions of all
     # dependencies that have a minimum version.
-    oldestdeps: numpy==1.18.*
-    oldestdeps: scipy==1.3.*
-    oldestdeps: astropy==4.3.*
+    oldestdeps: minimum_dependencies
 
     # The devdeps factor is intended to be used to install the latest developer version
     # or nightly wheel of key dependencies.
     devdeps: git+https://github.com/astropy/specutils.git@main#egg=specutils
 
     cov: pytest-cov
-    cov: codecov
 
+    xdist: pytest-xdist
 extras =
     test
     alldeps: all
 
-commands =
+commands_pre = 
     devdeps: pip install -U -i https://pypi.anaconda.org/astropy/simple astropy --pre
     pip freeze
-    !cov: pytest --pyargs synphot {toxinidir}/docs {posargs}
-    cov: pytest --pyargs synphot {toxinidir}/docs --cov synphot --cov-config={toxinidir}/setup.cfg {posargs}
-    cov: coverage xml -o {toxinidir}/coverage.xml
+    
+commands =
+    pytest --pyargs synphot {tox_root}/docs \
+    cov: --cov synphot --cov-config {tox_root}/setup.cfg --cov-report xml --cov-report term-missing \
+    xdist: -n auto \
+    {posargs}
 
 pip_pre =
     predeps: true
     !predeps: false
-
-[testenv:codestyle]
+    
+[testenv:check-style]
 skip_install = true
 changedir = {toxinidir}
 description = check code style with flake8
 deps = flake8
 commands = flake8 synphot --count
 
-[testenv:twine]
+[testenv:check-security]
+skip_install = true
+changedir = {tox_root}
+description = Security audit with bandit
+deps = 
+    bandit
+commands =
+    bandit -r synphot -c .bandit.yaml
+
+[testenv:check-docs]
+change_dir = docs
+description = check the links in the HTML docs
+extras = 
+    docs
+allowlist_externals = 
+    make
+commands =
+    make linkcheck
+
+[testenv:build-dist]
 skip_install = true
 changedir = {toxinidir}
 description = twine check dist tarball
@@ -78,24 +100,5 @@ deps =
     build
     twine>=3.3
 commands =
-    pip freeze
     python -m build --sdist .
     twine check --strict dist/*
-
-[testenv:bandit]
-skip_install = true
-changedir = {toxinidir}
-description = Security audit with bandit
-deps = bandit
-commands =
-    pip freeze
-    bandit -r synphot -c .bandit.yaml
-
-[testenv:linkcheck]
-changedir = docs
-description = check the links in the HTML docs
-extras = docs
-allowlist_externals = make
-commands =
-    pip freeze
-    make linkcheck


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/synphot_refactor/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request consolidates CI jobs in GitHub Actions to use the OpenAstronomy reusable workflow, and also updates the Tox configuration to use new keyword aliases. Additionally, adds the `-xdist` factor to run `pytest-xdist`

<img width="779" alt="image" src="https://user-images.githubusercontent.com/16024299/230152707-4c4ad183-c307-48c3-abff-99ddb04ae6c5.png">

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
