### PR TITLE
remove unsupported `system_packages` RTD config setting

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,6 @@ sphinx:
   fail_on_warning: true
 
 python:
-  system_packages: false
   install:
     - method: pip
       path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,10 +128,10 @@ man_pages = [('index', project.lower(), project + u' Documentation',
 # -- Options for intersphinx --------------------------------------------------
 
 intersphinx_mapping.update({
-    'astropy': ('https://docs.astropy.org/en/latest/', None),
+    'astropy': ('https://docs.astropy.org/en/stable/', None),
     'stsynphot': ('https://stsynphot.readthedocs.io/en/latest/', None),
-    'specutils': ('https://specutils.readthedocs.io/en/latest/', None),
-    'dust-extinction': ('https://dust-extinction.readthedocs.io/en/latest/', None)})
+    'specutils': ('https://specutils.readthedocs.io/en/stable/', None),
+    'dust-extinction': ('https://dust-extinction.readthedocs.io/en/stable/', None)})
 
 # -- Options for linkcheck output ---------------------------------------------
 linkcheck_retry = 5


### PR DESCRIPTION

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/synphot_refactor/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->



<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->
RTD no longer supports any `system_packages` setting: https://blog.readthedocs.com/drop-support-system-packages/

This PR removes the unused `system_packages` setting

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->