### PR TITLE
MNT: upgrade upload/download-artifact GitHub actions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -55,14 +55,9 @@ jobs:
         path: ./wheelhouse/*.whl
 
   build_dist:
-    name: Source dist and publish
+    name: Source dist
     runs-on: ubuntu-latest
-    needs: build_wheels
-    environment:
-      name: release
-      url: https://pypi.org/p/synphot
-    permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    if: (github.repository == 'spacetelescope/synphot_refactor' && ( github.event_name == 'release' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build wheels')))
     steps:
     - uses: actions/checkout@v4
       with:
@@ -84,13 +79,31 @@ jobs:
         testenv/bin/pip install pytest pytest-astropy
         testenv/bin/pip install synphot_refactor/dist/*.tar.gz
         testenv/bin/python -c "import synphot; synphot.test()"
-    - name: Download wheels
+    - name: Upload dist
       if: github.event_name == 'release'
+      uses: actions/upload-artifact@v4
+      with:
+        name: additional-pylons-dist
+        path: ./dist/*.tar.gz
+
+  publish:
+    name: Publish to PyPI
+    needs: [build_wheels, build_dist]
+    if: github.repository == 'spacetelescope/synphot_refactor' && github.event_name == 'release'
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/p/synphot
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - name: Download wheels
       uses: actions/download-artifact@v4
       with:
         path: dist
         pattern: additional-pylons-*
         merge-multiple: true
+    - name: Pylons inspection
+      run: ls dist/*
     - name: Publish package to PyPI
-      if: github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -49,9 +49,9 @@ jobs:
     # Upload artifacts because gh-action-pypi-publish Docker is only on Linux
     - name: Upload wheels
       if: github.event_name == 'release'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: additional-pylons
+        name: additional-pylons-${{ matrix.os }}
         path: ./wheelhouse/*.whl
 
   build_dist:
@@ -86,10 +86,11 @@ jobs:
         testenv/bin/python -c "import synphot; synphot.test()"
     - name: Download wheels
       if: github.event_name == 'release'
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-        name: additional-pylons
         path: dist
+        pattern: additional-pylons-*
+        merge-multiple: true
     - name: Publish package to PyPI
       if: github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
### Description

Hi, version 4 of upload-artifact and download-artifact were recently released.
Staying on old version is not viable long term because GitHub will sooner or later drop support for the old versions of node that these depend on.
Since migration to v4 is not as straightfoward as bumping the version number, I'm helping all astropy-related packages byt manually performing the necessary changes.
