### PR TITLE
TST: filter_par.rst result is from numpy<2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ doctest_subpackage_requires =
     docs/index.rst = astropy>=5.3
     docs/synphot/spectrum.rst = astropy>=5.3
     docs/synphot/tutorials.rst = astropy>=5.3
+    docs/synphot/filter_par.rst = numpy<2
 text_file_format = rst
 addopts = --doctest-rst --import-mode=append
 xfail_strict = true


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/synphot_refactor/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

`filter_par.rst` result is from numpy<2 and needs to be updated when we run it with numpy>=2

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #374
