### PR TITLE
Force flux_unit to be unit instance

### DIFF
--- a/synphot/spectrum.py
+++ b/synphot/spectrum.py
@@ -484,7 +484,7 @@ class BaseSpectrum:
                 raise exceptions.SynphotError(
                     'flux_unit cannot be used with unitless spectrum')
             else:
-                self._validate_flux_unit(flux_unit, wav_only=True)
+                flux_unit = self._validate_flux_unit(flux_unit, wav_only=True)
 
         x = self._validate_wavelengths(wavelengths)
 


### PR DESCRIPTION
Force flux_unit to be unit instance instead of a str to be compatible with astropy v7.1

xref https://github.com/astropy/astropy/pull/17586

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/synphot_refactor/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->
