### PR TITLE
MNT: Replace ubuntu-20.04 with ubuntu-22.04

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -81,7 +81,7 @@ jobs:
             toxenv: py313-test-devdeps
 
           - name: Test with old dependencies
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             python: '3.10'
             toxenv: py310-test-oldestdeps
 


### PR DESCRIPTION
As recommended by actions/runner-images#11101 , this PR replaces the deprecated ubuntu-20.04 runner with a newer version. This also replaces RTD workflow, if applicable, to future-proof the build in case it follows suit.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.

[:ghost:](https://github.com/pllim/playpen/issues/63)