### PR TITLE
Use default Vega spectrum for flux conversions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 ==================
 
 - Flux conversions to and from VEGAMAG now use the default Vega spectrum
-  (``synphot.spectrum.Vega``) if no Vega spectrum is given, instead of
+  (``synphot.spectrum.Vega``) if no valid Vega spectrum is given, instead of
   throwing an exception. To that end, a new ``synphot.spectrum.lazy_load_vega()``
   function is also introduced. [#435]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,9 @@
 ==================
 
 - Flux conversions to and from VEGAMAG now use the default Vega spectrum
-  if no Vega spectrum is given. [#435]
+  (``synphot.spectrum.Vega``) if no Vega spectrum is given, instead of
+  throwing an exception. To that end, a new ``synphot.spectrum.lazy_load_vega()``
+  function is also introduced. [#435]
 
 1.6.1 (2025-12-10)
 ==================
@@ -69,7 +71,7 @@
 - OBMAG and VEGAMAG are no longer interchangeable. [#331]
 
 - ``Box1D`` model now takes optional ``step`` input to allow user control
-  over the generated sampleset. Default behavior maintains backwards 
+  over the generated sampleset. Default behavior maintains backwards
   compatibility. [#342]
 
 - Dropped support for Python 3.6 and 3.7. Minimum supported Python

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 1.7.0 (unreleased)
 ==================
 
+- Flux conversions to and from VEGAMAG now use the default Vega spectrum
+  if no Vega spectrum is given. [#435]
+
 1.6.1 (2025-12-10)
 ==================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -337,6 +337,7 @@ Also imports this C-extension to local namespace:
 
 .. automodapi:: synphot.spectrum
    :no-inheritance-diagram:
+   :include-all-objects:
 
 .. automodapi:: synphot.thermal
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,7 @@ synphot.filter_parameterization.tests = data/*
 # I201: Missing newline before sections or imports
 # W504: line break after binary operator
 ignore = I100,I201,W504
+max-line-length = 125
 
 [coverage:run]
 source = synphot

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -24,8 +24,7 @@ from synphot.models import Empirical1D
 from synphot.spectrum import (
     BaseSourceSpectrum,
     SourceSpectrum,
-    SpectralElement,
-    _get_cached_vega,
+    SpectralElement
 )
 
 __all__ = ['Observation']
@@ -475,7 +474,9 @@ class Observation(BaseSourceSpectrum):
         # This is basically effstim(self)/effstim(Vega)
         if flux_unit_name == units.VEGAMAG.to_string():
             if vegaspec is None:
-                vegaspec = _get_cached_vega()
+                from synphot import spectrum
+                spectrum.lazy_load_vega()
+                vegaspec = spectrum.Vega
 
             num = self.integrate(wavelengths=wavelengths)
             den = (vegaspec * self.bandpass).integrate(
@@ -649,10 +650,7 @@ class Observation(BaseSourceSpectrum):
             Flux is converted to this unit for plotting.
             If not given, internal unit is used.
 
-        area : float or `~astropy.units.quantity.Quantity`
-            See :func:`~synphot.units.convert_flux`.
-
-        vegaspec : `~synphot.spectrum.SourceSpectrum`
+        area, vegaspec
             See :func:`~synphot.units.convert_flux`.
 
         kwargs : dict

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -472,7 +472,7 @@ class Observation(BaseSourceSpectrum):
         if flux_unit_name == units.VEGAMAG.to_string():
             if not isinstance(vegaspec, SourceSpectrum):
                 from synphot import spectrum
-                spectrum.lazy_load_vega()
+                spectrum._lazy_load_vega_with_exception()
                 vegaspec = spectrum.Vega
 
             num = self.integrate(wavelengths=wavelengths)

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -21,8 +21,12 @@ from astropy.utils.exceptions import (AstropyUserWarning,
 # LOCAL
 from synphot import binning, exceptions, units, utils
 from synphot.models import Empirical1D
-from synphot.spectrum import (BaseSourceSpectrum, SourceSpectrum,
-                              SpectralElement)
+from synphot.spectrum import (
+    BaseSourceSpectrum,
+    SourceSpectrum,
+    SpectralElement,
+    _get_cached_vega,
+)
 
 __all__ = ['Observation']
 
@@ -471,10 +475,8 @@ class Observation(BaseSourceSpectrum):
         # This is basically effstim(self)/effstim(Vega)
         if flux_unit_name == units.VEGAMAG.to_string():
             if vegaspec is None:
-                vegaspec = SourceSpectrum.from_vega()
-            # Vega data file missing, so from_vega above returns None.
-            if not isinstance(vegaspec, SourceSpectrum):
-                raise exceptions.SynphotError('Vega spectrum is missing.')
+                vegaspec = _get_cached_vega()
+
             num = self.integrate(wavelengths=wavelengths)
             den = (vegaspec * self.bandpass).integrate(
                 integration_type='trapezoid')

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -21,11 +21,8 @@ from astropy.utils.exceptions import (AstropyUserWarning,
 # LOCAL
 from synphot import binning, exceptions, units, utils
 from synphot.models import Empirical1D
-from synphot.spectrum import (
-    BaseSourceSpectrum,
-    SourceSpectrum,
-    SpectralElement
-)
+from synphot.spectrum import (BaseSourceSpectrum, SourceSpectrum,
+                              SpectralElement)
 
 __all__ = ['Observation']
 
@@ -473,7 +470,7 @@ class Observation(BaseSourceSpectrum):
         # Special handling of VEGAMAG.
         # This is basically effstim(self)/effstim(Vega)
         if flux_unit_name == units.VEGAMAG.to_string():
-            if vegaspec is None:
+            if not isinstance(vegaspec, SourceSpectrum):
                 from synphot import spectrum
                 spectrum.lazy_load_vega()
                 vegaspec = spectrum.Vega

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -470,6 +470,9 @@ class Observation(BaseSourceSpectrum):
         # Special handling of VEGAMAG.
         # This is basically effstim(self)/effstim(Vega)
         if flux_unit_name == units.VEGAMAG.to_string():
+            if vegaspec is None:
+                vegaspec = SourceSpectrum.from_vega()
+            # Vega data file missing, so from_vega() returns None.
             if not isinstance(vegaspec, SourceSpectrum):
                 raise exceptions.SynphotError('Vega spectrum is missing.')
             num = self.integrate(wavelengths=wavelengths)
@@ -644,8 +647,12 @@ class Observation(BaseSourceSpectrum):
             Flux is converted to this unit for plotting.
             If not given, internal unit is used.
 
-        area, vegaspec
+        area:
             See :func:`~synphot.units.convert_flux`.
+        vegaspec : `~synphot.spectrum.SourceSpectrum`
+            If this kwarg is present, the given Vega spectrum to use for conversion
+            of VEGAMAG. If not present, it is automatically loaded from
+            :func:`~synphot.spectrum.SourceSpectrum.from_vega`.
 
         kwargs : dict
             See :func:`synphot.spectrum.BaseSpectrum.plot`.

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -647,7 +647,7 @@ class Observation(BaseSourceSpectrum):
             Flux is converted to this unit for plotting.
             If not given, internal unit is used.
 
-        area : float
+        area : float or `~astropy.units.quantity.Quantity`
             See :func:`~synphot.units.convert_flux`.
 
         vegaspec : `~synphot.spectrum.SourceSpectrum`

--- a/synphot/observation.py
+++ b/synphot/observation.py
@@ -472,7 +472,7 @@ class Observation(BaseSourceSpectrum):
         if flux_unit_name == units.VEGAMAG.to_string():
             if vegaspec is None:
                 vegaspec = SourceSpectrum.from_vega()
-            # Vega data file missing, so from_vega() returns None.
+            # Vega data file missing, so from_vega above returns None.
             if not isinstance(vegaspec, SourceSpectrum):
                 raise exceptions.SynphotError('Vega spectrum is missing.')
             num = self.integrate(wavelengths=wavelengths)
@@ -647,12 +647,11 @@ class Observation(BaseSourceSpectrum):
             Flux is converted to this unit for plotting.
             If not given, internal unit is used.
 
-        area:
+        area : float
             See :func:`~synphot.units.convert_flux`.
+
         vegaspec : `~synphot.spectrum.SourceSpectrum`
-            If this kwarg is present, the given Vega spectrum to use for conversion
-            of VEGAMAG. If not present, it is automatically loaded from
-            :func:`~synphot.spectrum.SourceSpectrum.from_vega`.
+            See :func:`~synphot.units.convert_flux`.
 
         kwargs : dict
             See :func:`synphot.spectrum.BaseSpectrum.plot`.

--- a/synphot/spectrum.py
+++ b/synphot/spectrum.py
@@ -70,10 +70,10 @@ def lazy_load_vega(vegafile=None, **kwargs):
     kwargs : dict
         Keywords acceptable by :func:`synphot.specio.read_remote_spec`.
 
-    Raises
-    ------
-    synphot.exceptions.SynphotError
-        Vega failed to load and set to `None` instead.
+    Returns
+    -------
+    err_message : str
+        Error message, if any.
 
     """
     global Vega
@@ -89,11 +89,22 @@ def lazy_load_vega(vegafile=None, **kwargs):
             Vega = SourceSpectrum.from_vega(**kwargs)
         except Exception as e:
             Vega = None
-            new_err_message = (
-                f"Need Vega spectrum for conversion but cannot load: {e.args[0]}\n"
-                "Fix loading or provide Vega spectrum as argument."
-            )
-            raise exceptions.SynphotError((new_err_message, ) + e.args[1:]) from None
+            err_message = repr(e)
+        else:
+            err_message = ""
+
+    return err_message
+
+
+def _lazy_load_vega_with_exception(**kwargs):
+    """Run :func:`lazy_load_vega` but throw exception for internal use."""
+    err_message = lazy_load_vega(**kwargs)
+    if err_message:
+        new_err_message = (
+            f"Failed to load a built-in Vega spectrum: {err_message}\n"
+            "Fix loading in lazy_load_vega() function or provide it directly via vegaspec keyword."
+        )
+        raise exceptions.SynphotError(new_err_message) from None
 
 
 # TODO: Update model logic when astropy.modeling supports Quantity.
@@ -1136,7 +1147,7 @@ class BaseSourceSpectrum(BaseSpectrum):
             # VEGAMAG
             if renorm_unit_name == units.VEGAMAG.to_string():
                 if not isinstance(vegaspec, SourceSpectrum):
-                    lazy_load_vega()
+                    _lazy_load_vega_with_exception()
                     stdspec = Vega
                 else:
                     stdspec = vegaspec

--- a/synphot/spectrum.py
+++ b/synphot/spectrum.py
@@ -32,6 +32,7 @@ __all__ = [
     "SourceSpectrum",
     "BaseUnitlessSpectrum",
     "SpectralElement",
+    "lazy_load_vega",
     "Vega",
 ]
 
@@ -44,24 +45,55 @@ Vega = (
 This is lazily loaded when needed using :func:`SourceSpectrum.from_vega()`.
 There are several mechanisms to use a different spectrum for Vega:
 
-- Set ``synphot.conf.vega_file``
-- Set ``synphot.spectrum.Vega`` before it is used
+- Reset ``synphot.spectrum.Vega`` to `None` and reload using :func:`lazy_load_vega` before it is used
 - Provide Vega spectrum as argument to conversion functions that require it (e.g., :func:`synphot.units.convert_flux`).
 """
 
 
-def _get_cached_vega():
+def lazy_load_vega(vegafile=None, **kwargs):
+    """Convenience function to load a default Vega spectrum that is
+    used throughout ``synphot`` when no specific Vega spectrum is given.
+
+    This function only does lazy loading; i.e., it will simply
+    return any previously loaded Vega, if available. To force a reload,
+    set `synphot.spectrum.Vega` to `None` before running this function.
+
+    `synphot.spectrum.Vega` would be loaded as a
+    `~synphot.spectrum.SourceSpectrum` if successful; otherwise `None`.
+
+    Parameters
+    ----------
+    vegafile : str or `None`, optional
+        Vega spectrum filename.
+        If `None`, use ``synphot.config.conf.vega_file``.
+
+    kwargs : dict
+        Keywords acceptable by :func:`synphot.specio.read_remote_spec`.
+
+    Raises
+    ------
+    synphot.exceptions.SynphotError
+        Vega failed to load and set to `None` instead.
+
+    """
     global Vega
-    if Vega is None:
+
+    if isinstance(Vega, SourceSpectrum):  # no-op
+        return
+
+    if vegafile is None:
+        vegafile = conf.vega_file
+
+    with conf.set_temp("vega_file", vegafile):
         try:
-            Vega = SourceSpectrum.from_vega()
+            Vega = SourceSpectrum.from_vega(**kwargs)
         except Exception as e:
-            new_message = (
+            Vega = None
+            new_err_message = (
                 f"Need Vega spectrum for conversion but cannot load: {e.args[0]}\n"
+                "Fix loading or provide Vega spectrum as argument."
             )
-            new_message += "Fix loading or provide Vega spectrum as argument."
-            raise exceptions.SynphotError((new_message,) + e.args[1:]) from None
-    return Vega
+            raise exceptions.SynphotError((new_err_message, ) + e.args[1:]) from None
 
 
 # TODO: Update model logic when astropy.modeling supports Quantity.
@@ -1104,7 +1136,8 @@ class BaseSourceSpectrum(BaseSpectrum):
             # VEGAMAG
             if renorm_unit_name == units.VEGAMAG.to_string():
                 if not isinstance(vegaspec, SourceSpectrum):
-                    stdspec = _get_cached_vega()
+                    lazy_load_vega()
+                    stdspec = Vega
                 else:
                     stdspec = vegaspec
 

--- a/synphot/spectrum.py
+++ b/synphot/spectrum.py
@@ -26,8 +26,42 @@ from synphot import exceptions, specio, units, utils
 from synphot.config import Conf, conf
 from synphot.models import ConstFlux1D, Empirical1D, get_waveset, get_metadata
 
-__all__ = ['BaseSpectrum', 'BaseSourceSpectrum', 'SourceSpectrum',
-           'BaseUnitlessSpectrum', 'SpectralElement']
+__all__ = [
+    "BaseSpectrum",
+    "BaseSourceSpectrum",
+    "SourceSpectrum",
+    "BaseUnitlessSpectrum",
+    "SpectralElement",
+    "Vega",
+]
+
+
+Vega = (
+    None  # This is defined at the end of this module to avoid circular import issues.
+)
+"""Default Vega spectrum. Used for conversions to and from VEGAMAG when no Vega spectrum is given.
+
+This is lazily loaded when needed using :func:`SourceSpectrum.from_vega()`.
+There are several mechanisms to use a different spectrum for Vega:
+- Set ``synphot.conf.vega_file``
+- Set ``synphot.spectrum.Vega`` before it is used
+- Provide Vega spectrum as argument to conversion functions that require it (e.g., ``units.convert_flux``).
+"""
+
+
+def _get_cached_vega():
+    global Vega
+    if Vega is None:
+        try:
+            Vega = SourceSpectrum.from_vega()
+        except Exception as e:
+            new_message = (
+                f"Need Vega spectrum for conversion but cannot load: {e.args[0]}\n"
+            )
+            new_message += "Fix loading or provide Vega spectrum as argument."
+            e.args = (new_message,) + e.args[1:]
+            raise exceptions.SynphotError((new_message,) + e.args[1:])
+    return Vega
 
 
 # TODO: Update model logic when astropy.modeling supports Quantity.
@@ -1069,10 +1103,7 @@ class BaseSourceSpectrum(BaseSpectrum):
 
             # VEGAMAG
             if renorm_unit_name == units.VEGAMAG.to_string():
-                if not isinstance(vegaspec, SourceSpectrum):
-                    raise exceptions.SynphotError(
-                        'Vega spectrum is missing.')
-                stdspec = vegaspec
+                stdspec = _get_cached_vega()
 
             # Magnitude flux-density units
             elif renorm_val.unit in (u.STmag, u.ABmag):

--- a/synphot/spectrum.py
+++ b/synphot/spectrum.py
@@ -43,9 +43,10 @@ Vega = (
 
 This is lazily loaded when needed using :func:`SourceSpectrum.from_vega()`.
 There are several mechanisms to use a different spectrum for Vega:
+
 - Set ``synphot.conf.vega_file``
 - Set ``synphot.spectrum.Vega`` before it is used
-- Provide Vega spectrum as argument to conversion functions that require it (e.g., ``units.convert_flux``).
+- Provide Vega spectrum as argument to conversion functions that require it (e.g., :func:`synphot.units.convert_flux`).
 """
 
 
@@ -59,8 +60,7 @@ def _get_cached_vega():
                 f"Need Vega spectrum for conversion but cannot load: {e.args[0]}\n"
             )
             new_message += "Fix loading or provide Vega spectrum as argument."
-            e.args = (new_message,) + e.args[1:]
-            raise exceptions.SynphotError((new_message,) + e.args[1:])
+            raise exceptions.SynphotError((new_message,) + e.args[1:]) from None
     return Vega
 
 
@@ -1103,7 +1103,10 @@ class BaseSourceSpectrum(BaseSpectrum):
 
             # VEGAMAG
             if renorm_unit_name == units.VEGAMAG.to_string():
-                stdspec = _get_cached_vega()
+                if not isinstance(vegaspec, SourceSpectrum):
+                    stdspec = _get_cached_vega()
+                else:
+                    stdspec = vegaspec
 
             # Magnitude flux-density units
             elif renorm_val.unit in (u.STmag, u.ABmag):

--- a/synphot/spectrum.py
+++ b/synphot/spectrum.py
@@ -45,7 +45,7 @@ Vega = (
 This is lazily loaded when needed using :func:`SourceSpectrum.from_vega()`.
 There are several mechanisms to use a different spectrum for Vega:
 
-- Reset ``synphot.spectrum.Vega`` to `None` and reload using :func:`lazy_load_vega` before it is used
+- Reset ``synphot.spectrum.Vega`` to `None` and reload using :func:`lazy_load_vega` before it is used.
 - Provide Vega spectrum as argument to conversion functions that require it (e.g., :func:`synphot.units.convert_flux`).
 """
 

--- a/synphot/tests/test_observation.py
+++ b/synphot/tests/test_observation.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 # ASTROPY
+import astropy
 from astropy import units as u
 from astropy.modeling.models import Const1D
 from astropy.tests.helper import assert_quantity_allclose
@@ -26,6 +27,7 @@ from synphot.models import (
 )
 from synphot.observation import Observation
 from synphot.spectrum import SourceSpectrum, SpectralElement
+from synphot import spectrum
 from synphot import conf
 
 # Global test data files
@@ -350,16 +352,14 @@ class TestObsPar:
         when the Vega spectrum cannot be loaded, we temporarily
         modify the package configuration to point to a non-existent Vega file.
         """
-        conf_vega_file = conf.vega_file
-        try:
-            conf.vega_file = ""
+        with astropy.conf.set_temp("vega_file", ""):
+            # spectrum.Vega is cached it might have been filled by previous tests
+            spectrum.Vega = None
             with pytest.raises(
                 exceptions.SynphotError,
                 match=message,
             ):
                 self.obs.effstim(flux_unit=flux_unit)
-        finally:
-            conf.vega_file = conf_vega_file
 
     @pytest.mark.remote_data
     def test_effstim_vegamag_vegaspec_default(self):

--- a/synphot/tests/test_observation.py
+++ b/synphot/tests/test_observation.py
@@ -10,7 +10,6 @@ import numpy as np
 import pytest
 
 # ASTROPY
-import astropy
 from astropy import units as u
 from astropy.modeling.models import Const1D
 from astropy.tests.helper import assert_quantity_allclose

--- a/synphot/tests/test_observation.py
+++ b/synphot/tests/test_observation.py
@@ -26,6 +26,7 @@ from synphot.models import (
 )
 from synphot.observation import Observation
 from synphot.spectrum import SourceSpectrum, SpectralElement
+from synphot import conf
 
 # Global test data files
 _specfile = get_pkg_data_filename(
@@ -336,6 +337,29 @@ class TestObsPar:
         np.testing.assert_allclose(
             self.obs.effstim(flux_unit=units.VEGAMAG, vegaspec=vspec).value,
             ans, rtol=0.001)
+
+    @pytest.mark.parametrize(
+        "flux_unit,message",
+        [
+            (u.mag, "Flux unit mag is invalid"),
+            (units.VEGAMAG, "Need Vega spectrum for conversion but cannot load"),
+        ],
+    )
+    def test_effstim_exceptions(self, flux_unit, message):
+        """By default, the Vega spectrum is lazily loaded when needed. To test the error
+        when the Vega spectrum cannot be loaded, we temporarily
+        modify the package configuration to point to a non-existent Vega file.
+        """
+        conf_vega_file = conf.vega_file
+        try:
+            conf.vega_file = ""
+            with pytest.raises(
+                exceptions.SynphotError,
+                match=message,
+            ):
+                self.obs.effstim(flux_unit=flux_unit)
+        finally:
+            conf.vega_file = conf_vega_file
 
     @pytest.mark.remote_data
     def test_effstim_vegamag_vegaspec_default(self):

--- a/synphot/tests/test_observation.py
+++ b/synphot/tests/test_observation.py
@@ -19,15 +19,14 @@ from astropy.utils.exceptions import (AstropyDeprecationWarning,
                                       AstropyUserWarning)
 
 # LOCAL
-from synphot.tests.test_units import _area
-from synphot import exceptions, units
+from synphot import conf, exceptions, spectrum, units
 from synphot.compat import HAS_SPECUTILS  # noqa
 from synphot.models import (
     BlackBodyNorm1D, Box1D, ConstFlux1D, Empirical1D, GaussianFlux1D
 )
 from synphot.observation import Observation
 from synphot.spectrum import SourceSpectrum, SpectralElement
-from synphot import spectrum
+from synphot.tests.test_units import _area
 
 # Global test data files
 _specfile = get_pkg_data_filename(
@@ -351,7 +350,7 @@ class TestObsPar:
         when the Vega spectrum cannot be loaded, we temporarily
         modify the package configuration to point to a non-existent Vega file.
         """
-        with astropy.conf.set_temp("vega_file", ""):
+        with conf.set_temp("vega_file", ""):
             # spectrum.Vega is cached it might have been filled by previous tests
             spectrum.Vega = None
             with pytest.raises(

--- a/synphot/tests/test_observation.py
+++ b/synphot/tests/test_observation.py
@@ -341,7 +341,7 @@ class TestObsPar:
         "flux_unit,message",
         [
             (u.mag, "Flux unit mag is invalid"),
-            (units.VEGAMAG, "Need Vega spectrum for conversion but cannot load"),
+            (units.VEGAMAG, "Failed to load a built-in Vega spectrum"),
         ],
     )
     def test_effstim_exceptions(self, flux_unit, message):

--- a/synphot/tests/test_observation.py
+++ b/synphot/tests/test_observation.py
@@ -337,12 +337,14 @@ class TestObsPar:
             self.obs.effstim(flux_unit=units.VEGAMAG, vegaspec=vspec).value,
             ans, rtol=0.001)
 
-    @pytest.mark.parametrize('flux_unit', [u.mag, units.VEGAMAG])
-    def test_effstim_exceptions(self, flux_unit):
-        with pytest.raises(exceptions.SynphotError):
-            self.obs.effstim(flux_unit=flux_unit)
-        with pytest.raises(exceptions.SynphotError):
-            self.obs.effstim(units.VEGAMAG)
+    @pytest.mark.remote_data
+    def test_effstim_vegamag_vegaspec_default(self):
+        ans = 12.737293324241517  # pysynphot 0.9.12.dev5
+        np.testing.assert_allclose(
+            self.obs.effstim(flux_unit=units.VEGAMAG).value,
+            ans,
+            rtol=0.001,
+        )
 
 
 class TestCountRate:

--- a/synphot/tests/test_observation.py
+++ b/synphot/tests/test_observation.py
@@ -28,7 +28,6 @@ from synphot.models import (
 from synphot.observation import Observation
 from synphot.spectrum import SourceSpectrum, SpectralElement
 from synphot import spectrum
-from synphot import conf
 
 # Global test data files
 _specfile = get_pkg_data_filename(

--- a/synphot/tests/test_spectrum_source.py
+++ b/synphot/tests/test_spectrum_source.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 # ASTROPY
+import astropy
 from astropy import modeling
 from astropy import units as u
 from astropy.io import fits
@@ -60,7 +61,7 @@ def teardown_module(module):
      (_flux_vegamag, units.PHOTLAM, _flux_photlam),
      (_flux_jy, units.VEGAMAG, _flux_vegamag),
      (_flux_vegamag, u.Jy, _flux_jy)])
-def test_flux_conversion_vega(in_q, out_u, ans):
+def test_flux_conversion_vega_buildin(in_q, out_u, ans):
     """Test Vega spectrum object and flux conversion with VEGAMAG.
 
     .. note:: 1% is good enough given Vega gets updated from time to time.
@@ -528,15 +529,11 @@ class TestNormalize:
     def test_exception_missing_vegaspec(self):
         """This is the same logic as "test_exception" but pulled out
         into a separate test because it needs more setup."""
-        conf_vega_file = conf.vega_file
-        try:
-            conf.vega_file = ""
+        with astropy.config.set_temp("vega_file", ""):
             # spectrum.Vega is cached it might have been filled by previous tests
             spectrum.Vega = None
             with pytest.raises(exceptions.SynphotError):
                 self.bb.normalize(10 * units.VEGAMAG, band=self.abox)
-        finally:
-            conf.vega_file = conf_vega_file
 
 
 class TestRedShift:

--- a/synphot/tests/test_spectrum_source.py
+++ b/synphot/tests/test_spectrum_source.py
@@ -21,6 +21,7 @@ from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
 
 # LOCAL
+from synphot.config import conf
 from synphot.tests.test_units import (
     _area, _wave, _flux_jy, _flux_photlam, _flux_vegamag
 )
@@ -31,6 +32,7 @@ from synphot.models import (
     GaussianFlux1D, Lorentz1D, RickerWavelet1D, PowerLawFlux1D)
 from synphot.observation import Observation
 from synphot.spectrum import SourceSpectrum, SpectralElement
+from synphot import spectrum
 
 
 def setup_module(module):
@@ -518,14 +520,23 @@ class TestNormalize:
         with pytest.raises(exceptions.DisjointError):
             self.em.normalize(10, band=bp)
 
-        # Missing Vega spectrum
-        with pytest.raises(exceptions.SynphotError):
-            self.bb.normalize(10 * units.VEGAMAG, band=self.abox)
-
         # Zero flux
         sp = SourceSpectrum(Const1D, amplitude=0)
         with pytest.raises(exceptions.SynphotError):
             sp.normalize(100 * u.ct, band=self.abox, area=_area)
+
+    def test_exception_missing_vegaspec(self):
+        """This is the same logic as "test_exception" but pulled out
+        into a separate test because it needs more setup."""
+        conf_vega_file = conf.vega_file
+        try:
+            conf.vega_file = ""
+            # spectrum.Vega is cached it might have been filled by previous tests
+            spectrum.Vega = None
+            with pytest.raises(exceptions.SynphotError):
+                self.bb.normalize(10 * units.VEGAMAG, band=self.abox)
+        finally:
+            conf.vega_file = conf_vega_file
 
 
 class TestRedShift:

--- a/synphot/tests/test_spectrum_source.py
+++ b/synphot/tests/test_spectrum_source.py
@@ -25,7 +25,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 from synphot.tests.test_units import (
     _area, _wave, _flux_jy, _flux_photlam, _flux_vegamag
 )
-from synphot import exceptions, units
+from synphot import conf, exceptions, units
 from synphot.compat import HAS_SPECUTILS
 from synphot.models import (
     BlackBodyNorm1D, Box1D, ConstFlux1D, Empirical1D, Gaussian1D,
@@ -528,7 +528,7 @@ class TestNormalize:
     def test_exception_missing_vegaspec(self):
         """This is the same logic as "test_exception" but pulled out
         into a separate test because it needs more setup."""
-        with astropy.config.set_temp("vega_file", ""):
+        with conf.set_temp("vega_file", ""):
             # spectrum.Vega is cached it might have been filled by previous tests
             spectrum.Vega = None
             with pytest.raises(exceptions.SynphotError):

--- a/synphot/tests/test_spectrum_source.py
+++ b/synphot/tests/test_spectrum_source.py
@@ -10,7 +10,6 @@ import numpy as np
 import pytest
 
 # ASTROPY
-import astropy
 from astropy import modeling
 from astropy import units as u
 from astropy.io import fits

--- a/synphot/tests/test_spectrum_source.py
+++ b/synphot/tests/test_spectrum_source.py
@@ -32,9 +32,6 @@ from synphot.models import (
 from synphot.observation import Observation
 from synphot.spectrum import SourceSpectrum, SpectralElement
 
-# GLOBAL VARIABLES
-_vspec = None  # Loaded in test_load_vspec()
-
 
 def setup_module(module):
     import astropy.constants as const
@@ -55,13 +52,6 @@ def teardown_module(module):
 
 
 @pytest.mark.remote_data
-def test_load_vspec():
-    """Load VEGA spectrum once here to be used later."""
-    global _vspec
-    _vspec = SourceSpectrum.from_vega()
-
-
-@pytest.mark.remote_data
 @pytest.mark.parametrize(
     ('in_q', 'out_u', 'ans'),
     [(_flux_photlam, units.VEGAMAG, _flux_vegamag),
@@ -74,13 +64,38 @@ def test_flux_conversion_vega(in_q, out_u, ans):
     .. note:: 1% is good enough given Vega gets updated from time to time.
 
     """
-    result = units.convert_flux(_wave, in_q, out_u, vegaspec=_vspec)
+    result = units.convert_flux(_wave, in_q, out_u)
     assert_quantity_allclose(result, ans, rtol=1e-2)
 
     # Scalar
     i = 0
-    result = units.convert_flux(_wave[i], in_q[i], out_u, vegaspec=_vspec)
+    result = units.convert_flux(_wave[i], in_q[i], out_u)
     assert_quantity_allclose(result, ans[i], rtol=1e-2)
+
+
+@pytest.mark.parametrize(
+    ("in_q", "out_u", "identical_ans"),
+    [
+        (_flux_photlam, units.VEGAMAG, False),
+        (_flux_vegamag, units.PHOTLAM, False),
+        (_flux_jy, units.FLAM, True),
+    ],
+)
+def test_flux_conversion_vega_different_spec(in_q, out_u, identical_ans):
+    """test_flux_conversion_vega test with the Vega spectrum in the database.
+
+    Here, we check that the conversion gives different answers when using different
+    spectra for Vega. To make that really obvious and to avoid the need for remote data,
+    we try two different spectra that have little to do with the real Vega spectrum.
+    """
+    not_vega1 = SourceSpectrum(BlackBodyNorm1D, temperature=2500)
+    not_vega2 = SourceSpectrum(BlackBodyNorm1D, temperature=5500)
+    result1 = units.convert_flux(_wave, in_q, out_u, vegaspec=not_vega1)
+    result2 = units.convert_flux(_wave, in_q, out_u, vegaspec=not_vega2)
+    if identical_ans:
+        assert_quantity_allclose(result1, result2, rtol=1e-2)
+    else:
+        assert not (result1 == result2).all()
 
 
 class TestEmpiricalSourceFromFile:
@@ -461,8 +476,7 @@ class TestNormalize:
          ('em', 27.2856)])
     def test_renorm_vegamag(self, sp_type, ans_countrate):
         sp = self._select_sp(sp_type)
-        rn_sp = sp.normalize(20 * units.VEGAMAG, band=self.abox,
-                             vegaspec=_vspec)
+        rn_sp = sp.normalize(20 * units.VEGAMAG, band=self.abox)
         self._compare_countrate(rn_sp, ans_countrate)
 
     def test_renorm_noband_jy(self):

--- a/synphot/tests/test_spectrum_source.py
+++ b/synphot/tests/test_spectrum_source.py
@@ -22,7 +22,6 @@ from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
 
 # LOCAL
-from synphot.config import conf
 from synphot.tests.test_units import (
     _area, _wave, _flux_jy, _flux_photlam, _flux_vegamag
 )

--- a/synphot/tests/test_spectrum_source.py
+++ b/synphot/tests/test_spectrum_source.py
@@ -59,7 +59,7 @@ def teardown_module(module):
      (_flux_vegamag, units.PHOTLAM, _flux_photlam),
      (_flux_jy, units.VEGAMAG, _flux_vegamag),
      (_flux_vegamag, u.Jy, _flux_jy)])
-def test_flux_conversion_vega_buildin(in_q, out_u, ans):
+def test_flux_conversion_vega_builtin(in_q, out_u, ans):
     """Test Vega spectrum object and flux conversion with VEGAMAG.
 
     .. note:: 1% is good enough given Vega gets updated from time to time.
@@ -83,7 +83,7 @@ def test_flux_conversion_vega_buildin(in_q, out_u, ans):
     ],
 )
 def test_flux_conversion_vega_different_spec(in_q, out_u, identical_ans):
-    """test_flux_conversion_vega test with the Vega spectrum in the database.
+    """test_flux_conversion_vega_builtin test with the Vega spectrum in the database.
 
     Here, we check that the conversion gives different answers when using different
     spectra for Vega. To make that really obvious and to avoid the need for remote data,

--- a/synphot/tests/test_spectrum_source.py
+++ b/synphot/tests/test_spectrum_source.py
@@ -21,17 +21,16 @@ from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
 
 # LOCAL
-from synphot.tests.test_units import (
-    _area, _wave, _flux_jy, _flux_photlam, _flux_vegamag
-)
-from synphot import conf, exceptions, units
+from synphot import conf, exceptions, spectrum, units
 from synphot.compat import HAS_SPECUTILS
 from synphot.models import (
     BlackBodyNorm1D, Box1D, ConstFlux1D, Empirical1D, Gaussian1D,
     GaussianFlux1D, Lorentz1D, RickerWavelet1D, PowerLawFlux1D)
 from synphot.observation import Observation
 from synphot.spectrum import SourceSpectrum, SpectralElement
-from synphot import spectrum
+from synphot.tests.test_units import (
+    _area, _wave, _flux_jy, _flux_photlam, _flux_vegamag
+)
 
 
 def setup_module(module):

--- a/synphot/tests/test_units.py
+++ b/synphot/tests/test_units.py
@@ -166,10 +166,6 @@ def test_flux_conversion_exceptions():
     with pytest.raises(u.UnitsError):
         units.convert_flux(_wave, _flux_photlam, u.AA)
 
-    # Missing Vega spectrum
-    with pytest.raises(exceptions.SynphotError):
-        units.convert_flux(_wave, _flux_fnu, units.VEGAMAG, vegaspec=None)
-
     # Missing area
     with pytest.raises(exceptions.SynphotError):
         units.convert_flux(_wave, _flux_photlam, u.count, area=None)

--- a/synphot/units.py
+++ b/synphot/units.py
@@ -226,7 +226,7 @@ def _convert_flux(wavelengths, fluxes, out_flux_unit, area=None,
         if not isinstance(vegaspec, SourceSpectrum):
             from synphot import spectrum
 
-            spectrum.lazy_load_vega()
+            spectrum._lazy_load_vega_with_exception()
             vegaspec = spectrum.Vega
 
         flux_vega = vegaspec(wavelengths)

--- a/synphot/units.py
+++ b/synphot/units.py
@@ -144,8 +144,8 @@ def convert_flux(wavelengths, fluxes, out_flux_unit, **kwargs):
         OBMAG and count, otherwise it is not needed.
 
     vegaspec : `~synphot.spectrum.SourceSpectrum`
-        If this kwarg ispresent, the given Vega spectrum to use for conversion
-        of VEGAMAG. If not present, it is automatically loaded from
+        Vega spectrum for conversions involving
+        VEGAMAG, otherwise it is automatically loaded from
         :func:`~synphot.spectrum.SourceSpectrum.from_vega`.
 
     Returns
@@ -226,7 +226,7 @@ def _convert_flux(wavelengths, fluxes, out_flux_unit, area=None,
         if vegaspec is None:
             vegaspec = SourceSpectrum.from_vega()
 
-        # Vega data file not found, so `from_vega` returns None
+        # Vega data file not found, so from_vega above returns None
         if not isinstance(vegaspec, SourceSpectrum):
             raise exceptions.SynphotError('Vega spectrum is missing.')
 

--- a/synphot/units.py
+++ b/synphot/units.py
@@ -221,7 +221,9 @@ def _convert_flux(wavelengths, fluxes, out_flux_unit, area=None,
 
     # VEGAMAG
     if VEGAMAG.to_string() in flux_unit_names:
-        if vegaspec is None:
+        from synphot.spectrum import SourceSpectrum
+
+        if not isinstance(vegaspec, SourceSpectrum):
             from synphot import spectrum
 
             spectrum.lazy_load_vega()

--- a/synphot/units.py
+++ b/synphot/units.py
@@ -221,14 +221,10 @@ def _convert_flux(wavelengths, fluxes, out_flux_unit, area=None,
 
     # VEGAMAG
     if VEGAMAG.to_string() in flux_unit_names:
-        from synphot.spectrum import SourceSpectrum
-
         if vegaspec is None:
-            vegaspec = SourceSpectrum.from_vega()
+            from synphot.spectrum import _get_cached_vega
 
-        # Vega data file not found, so from_vega above returns None
-        if not isinstance(vegaspec, SourceSpectrum):
-            raise exceptions.SynphotError('Vega spectrum is missing.')
+            vegaspec = _get_cached_vega()
 
         flux_vega = vegaspec(wavelengths)
 

--- a/synphot/units.py
+++ b/synphot/units.py
@@ -144,9 +144,9 @@ def convert_flux(wavelengths, fluxes, out_flux_unit, **kwargs):
         OBMAG and count, otherwise it is not needed.
 
     vegaspec : `~synphot.spectrum.SourceSpectrum`
-        Vega spectrum that *must* be provided for conversions involving
-        VEGAMAG, otherwise it is not needed. For instance, it can be
-        obtained from :func:`~synphot.spectrum.SourceSpectrum.from_vega`.
+        If this kwarg ispresent, the given Vega spectrum to use for conversion
+        of VEGAMAG. If not present, it is automatically loaded from
+        :func:`~synphot.spectrum.SourceSpectrum.from_vega`.
 
     Returns
     -------
@@ -223,6 +223,10 @@ def _convert_flux(wavelengths, fluxes, out_flux_unit, area=None,
     if VEGAMAG.to_string() in flux_unit_names:
         from synphot.spectrum import SourceSpectrum
 
+        if vegaspec is None:
+            vegaspec = SourceSpectrum.from_vega()
+
+        # Vega data file not found, so `from_vega` returns None
         if not isinstance(vegaspec, SourceSpectrum):
             raise exceptions.SynphotError('Vega spectrum is missing.')
 

--- a/synphot/units.py
+++ b/synphot/units.py
@@ -222,9 +222,10 @@ def _convert_flux(wavelengths, fluxes, out_flux_unit, area=None,
     # VEGAMAG
     if VEGAMAG.to_string() in flux_unit_names:
         if vegaspec is None:
-            from synphot.spectrum import _get_cached_vega
+            from synphot import spectrum
 
-            vegaspec = _get_cached_vega()
+            spectrum.lazy_load_vega()
+            vegaspec = spectrum.Vega
 
         flux_vega = vegaspec(wavelengths)
 


### PR DESCRIPTION
There is only one Vega in the sky and most users will simply use the spectrum given the the database for their conversions. Thus, there is no reasons to already require them to explicitly put in a spectrum. With this PR, they still can, but if not, the conversion functions will try to load the default Vega spectrum if it's available.

Fixes #433


